### PR TITLE
Fix inconsistency with timestamps

### DIFF
--- a/TemplightTracer.cpp
+++ b/TemplightTracer.cpp
@@ -232,7 +232,7 @@ void TemplightTracer::atTemplateBeginImpl(const Sema &TheSema,
   // NOTE: Use this function because it produces time since start of process.
   llvm::sys::TimeValue now(0,0), user(0,0), sys(0,0);
   llvm::sys::Process::GetTimeUsage(now, user, sys);
-  if(user.seconds() != 0 && user.nanoseconds() != 0)
+  if(user.seconds() != 0 || user.nanoseconds() != 0)
     now = user;
   
   Entry.TimeStamp = now.seconds() + now.nanoseconds() / 1000000000.0;
@@ -255,7 +255,7 @@ void TemplightTracer::atTemplateEndImpl(const Sema &TheSema,
   // NOTE: Use this function because it produces time since start of process.
   llvm::sys::TimeValue now(0,0), user(0,0), sys(0,0);
   llvm::sys::Process::GetTimeUsage(now, user, sys);
-  if(user.seconds() != 0 && user.nanoseconds() != 0)
+  if(user.seconds() != 0 || user.nanoseconds() != 0)
     now = user;
   
   Entry.TimeStamp = now.seconds() + now.nanoseconds() / 1000000000.0;


### PR DESCRIPTION
Sometimes in the middle of profiling the condition in the removed ifs became true, and the timestamp values became inconsistent. (See #20)

Fixes #20