### PR TITLE
Create Sema lazily to support -code-complete-at.

### DIFF
--- a/TemplightAction.h
+++ b/TemplightAction.h
@@ -52,6 +52,9 @@ public:
   unsigned InteractiveDebug : 1;
   std::string OutputFilename;
   std::string BlackListFilename;
+
+private:
+  void EnsureHasSema(CompilerInstance& CI);
 };
 
 }


### PR DESCRIPTION
When -code-complete-at is used, the TemplightAction creates the
CodeCompletionConsumer object (because of creating the Sema) and
a FrontendAction TemplightAction wraps also tries to create the
CodeCompletionConsumer object. Clang breaks when the
CodeCompletionConsumer is created twice.

There is no way to tell the wrapped FrontendAction not to try to
(re)create the CodeCompletionConsumer. Because of this, the
templight executable does not support -code-completion-at.

This patch makes TemplightAction not to create the Sema (and the
CodeCompletionConsumer) unless the Templight functionality is asked
for. This way one can use -code-complete-at with the templight binary.
This fix is a workaround to make -code-complete-at work without
changing code in the Clang libraries.