### PR TITLE
Update for clang trunk, and extended template name detection

### DIFF
--- a/templight_clang_patch.diff
+++ b/templight_clang_patch.diff
@@ -207,7 +207,7 @@ diff --git include/clang/Sema/Sema.h include/clang/Sema/Sema.h
 index 2028d2c..8224524 100644
 --- include/clang/Sema/Sema.h
 +++ include/clang/Sema/Sema.h
-@@ -35,6 +35,7 @@
+@@ -36,6 +36,7 @@
  #include "clang/Basic/Specifiers.h"
  #include "clang/Basic/TemplateKinds.h"
  #include "clang/Basic/TypeTraits.h"
@@ -215,7 +215,7 @@ index 2028d2c..8224524 100644
  #include "clang/Sema/AnalysisBasedWarnings.h"
  #include "clang/Sema/CleanupInfo.h"
  #include "clang/Sema/DeclSpec.h"
-@@ -168,6 +169,7 @@ namespace clang {
+@@ -170,6 +171,7 @@
    class TemplateArgumentList;
    class TemplateArgumentLoc;
    class TemplateDecl;
@@ -223,132 +223,23 @@ index 2028d2c..8224524 100644
    class TemplateParameterList;
    class TemplatePartialOrderingContext;
    class TemplateTemplateParmDecl;
-@@ -6719,124 +6721,6 @@ public:
+@@ -6837,6 +6839,7 @@
                                 bool RelativeToPrimary = false,
                                 const FunctionDecl *Pattern = nullptr);
  
--  /// \brief A template instantiation that is currently in progress.
--  struct ActiveTemplateInstantiation {
--    /// \brief The kind of template instantiation we are performing
--    enum InstantiationKind {
--      /// We are instantiating a template declaration. The entity is
--      /// the declaration we're instantiating (e.g., a CXXRecordDecl).
--      TemplateInstantiation,
--
--      /// We are instantiating a default argument for a template
--      /// parameter. The Entity is the template parameter whose argument is
--      /// being instantiated, the Template is the template, and the
--      /// TemplateArgs/NumTemplateArguments provide the template arguments as
--      /// specified.
--      DefaultTemplateArgumentInstantiation,
--
--      /// We are instantiating a default argument for a function.
--      /// The Entity is the ParmVarDecl, and TemplateArgs/NumTemplateArgs
--      /// provides the template arguments as specified.
--      DefaultFunctionArgumentInstantiation,
--
--      /// We are substituting explicit template arguments provided for
--      /// a function template. The entity is a FunctionTemplateDecl.
--      ExplicitTemplateArgumentSubstitution,
--
--      /// We are substituting template argument determined as part of
--      /// template argument deduction for either a class template
--      /// partial specialization or a function template. The
--      /// Entity is either a ClassTemplatePartialSpecializationDecl or
--      /// a FunctionTemplateDecl.
--      DeducedTemplateArgumentSubstitution,
--
--      /// We are substituting prior template arguments into a new
--      /// template parameter. The template parameter itself is either a
--      /// NonTypeTemplateParmDecl or a TemplateTemplateParmDecl.
--      PriorTemplateArgumentSubstitution,
--
--      /// We are checking the validity of a default template argument that
--      /// has been used when naming a template-id.
--      DefaultTemplateArgumentChecking,
--
--      /// We are instantiating the exception specification for a function
--      /// template which was deferred until it was needed.
--      ExceptionSpecInstantiation
--    } Kind;
--
--    /// \brief The point of instantiation within the source code.
--    SourceLocation PointOfInstantiation;
--
--    /// \brief The template (or partial specialization) in which we are
--    /// performing the instantiation, for substitutions of prior template
--    /// arguments.
--    NamedDecl *Template;
--
--    /// \brief The entity that is being instantiated.
--    Decl *Entity;
--
--    /// \brief The list of template arguments we are substituting, if they
--    /// are not part of the entity.
--    const TemplateArgument *TemplateArgs;
--
--    /// \brief The number of template arguments in TemplateArgs.
--    unsigned NumTemplateArgs;
--
--    ArrayRef<TemplateArgument> template_arguments() const {
--      return {TemplateArgs, NumTemplateArgs};
--    }
--
--    /// \brief The template deduction info object associated with the
--    /// substitution or checking of explicit or deduced template arguments.
--    sema::TemplateDeductionInfo *DeductionInfo;
--
--    /// \brief The source range that covers the construct that cause
--    /// the instantiation, e.g., the template-id that causes a class
--    /// template instantiation.
--    SourceRange InstantiationRange;
--
--    ActiveTemplateInstantiation()
--      : Kind(TemplateInstantiation), Template(nullptr), Entity(nullptr),
--        TemplateArgs(nullptr), NumTemplateArgs(0), DeductionInfo(nullptr) {}
--
--    /// \brief Determines whether this template is an actual instantiation
--    /// that should be counted toward the maximum instantiation depth.
--    bool isInstantiationRecord() const;
--
--    friend bool operator==(const ActiveTemplateInstantiation &X,
--                           const ActiveTemplateInstantiation &Y) {
--      if (X.Kind != Y.Kind)
--        return false;
--
--      if (X.Entity != Y.Entity)
--        return false;
--
--      switch (X.Kind) {
--      case TemplateInstantiation:
--      case ExceptionSpecInstantiation:
--        return true;
--
--      case PriorTemplateArgumentSubstitution:
--      case DefaultTemplateArgumentChecking:
--        return X.Template == Y.Template && X.TemplateArgs == Y.TemplateArgs;
--
--      case DefaultTemplateArgumentInstantiation:
--      case ExplicitTemplateArgumentSubstitution:
--      case DeducedTemplateArgumentSubstitution:
--      case DefaultFunctionArgumentInstantiation:
--        return X.TemplateArgs == Y.TemplateArgs;
--
--      }
--
--      llvm_unreachable("Invalid InstantiationKind!");
--    }
--
--    friend bool operator!=(const ActiveTemplateInstantiation &X,
--                           const ActiveTemplateInstantiation &Y) {
--      return !(X == Y);
--    }
--  };
--
++#if 0
+   /// \brief A template instantiation that is currently in progress.
+   struct ActiveTemplateInstantiation {
+     /// \brief The kind of template instantiation we are performing
+@@ -6954,6 +6957,7 @@
+       return !(X == Y);
+     }
+   };
++#endif // 0
+ 
    /// \brief List of active template instantiations.
    ///
-   /// This vector is treated as a stack. As one template instantiation
-@@ -6888,6 +6772,13 @@ public:
+@@ -7010,6 +7014,13 @@
    /// to implement it anywhere else.
    ActiveTemplateInstantiation LastTemplateInstantiationErrorContext;
  


### PR DESCRIPTION
Some template names were coming out empty in the protobuf output. After conversion to callgrind format, these were causing assert failures in QCacheGrind. The offenders seemed to be unnamed template parameters, unnamed function parameters, and lambdas with init-captures. I don't know if my fix is the best or proper way, but it works for me.