### PR TITLE
Added new tests for each CodeSynthesisContext::Kind.

### DIFF
--- a/templight_clang_patch.diff
+++ b/templight_clang_patch.diff
@@ -222,7 +222,7 @@ index e6feaf7447..52b80c5de3 100644
      return false;
  
 diff --git a/lib/Frontend/FrontendActions.cpp b/lib/Frontend/FrontendActions.cpp
-index 9621889b27..896c40cace 100644
+index 9621889b27..e7556181e3 100644
 --- a/lib/Frontend/FrontendActions.cpp
 +++ b/lib/Frontend/FrontendActions.cpp
 @@ -18,12 +18,16 @@
@@ -242,7 +242,7 @@ index 9621889b27..896c40cace 100644
  #include <memory>
  #include <system_error>
  
-@@ -252,6 +256,149 @@ void VerifyPCHAction::ExecuteAction() {
+@@ -246,6 +250,149 @@ void VerifyPCHAction::ExecuteAction() {
  }
  
  namespace {
@@ -613,6 +613,386 @@ index 8c8402e75e..f66ade4d1b 100644
      }
  
      return false;
+diff --git a/test/Sema/templight-deduced-func.cpp b/test/Sema/templight-deduced-func.cpp
+new file mode 100644
+index 0000000000..0aa6c96187
+--- /dev/null
++++ b/test/Sema/templight-deduced-func.cpp
+@@ -0,0 +1,38 @@
++// RUN: %clang_cc1 -templight-dump %s 2>&1 | FileCheck %s
++
++template <class T>
++int foo(T){return 0;}
++
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+foo$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-deduced-func.cpp:}}[[@LINE+28]]{{:12'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+foo$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-deduced-func.cpp:}}[[@LINE+23]]{{:12'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-deduced-func.cpp:}}[[@LINE+17]]{{:12'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-deduced-func.cpp:}}[[@LINE+12]]{{:12'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-deduced-func.cpp:}}[[@LINE+6]]{{:12'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-deduced-func.cpp:}}[[@LINE+1]]{{:12'$}}
++int gvar = foo(0);
+diff --git a/test/Sema/templight-default-arg-inst.cpp b/test/Sema/templight-default-arg-inst.cpp
+new file mode 100644
+index 0000000000..ee8c9225f0
+--- /dev/null
++++ b/test/Sema/templight-default-arg-inst.cpp
+@@ -0,0 +1,70 @@
++// RUN: %clang_cc1 -templight-dump %s 2>&1 | FileCheck %s
++template<class T, class U = T>
++class A {};
++
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A::U'$}}
++// CHECK: {{^kind:[ ]+DefaultTemplateArgumentInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+61]]{{:1'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A::U'$}}
++// CHECK: {{^kind:[ ]+DefaultTemplateArgumentInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+56]]{{:1'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A::U'$}}
++// CHECK: {{^kind:[ ]+DefaultTemplateArgumentChecking$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+50]]{{:6'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A::U'$}}
++// CHECK: {{^kind:[ ]+DefaultTemplateArgumentChecking$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+45]]{{:6'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+39]]{{:8'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+34]]{{:8'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+28]]{{:8'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+23]]{{:8'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+17]]{{:8'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+12]]{{:8'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+6]]{{:8'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int, int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-arg-inst.cpp:}}[[@LINE+1]]{{:8'$}}
++A<int> a;
+diff --git a/test/Sema/templight-default-func-arg.cpp b/test/Sema/templight-default-func-arg.cpp
+new file mode 100644
+index 0000000000..c9b5a0e959
+--- /dev/null
++++ b/test/Sema/templight-default-func-arg.cpp
+@@ -0,0 +1,63 @@
++// RUN: %clang_cc1 -std=c++14 -templight-dump %s 2>&1 | FileCheck %s
++template <class T>
++void foo(T b = 0) {};
++
++int main()
++{
++
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+foo$}}
++// CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+50]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+foo$}}
++// CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+45]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+foo$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+39]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+foo$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+34]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+28]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+23]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+b$}}
++// CHECK: {{^kind:[ ]+DefaultFunctionArgumentInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+17]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+b$}}
++// CHECK: {{^kind:[ ]+DefaultFunctionArgumentInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+12]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+6]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'foo<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-func-arg.cpp:}}[[@LINE+1]]{{:3'$}}
++  foo<int>();
++}
+diff --git a/test/Sema/templight-default-template-arg.cpp b/test/Sema/templight-default-template-arg.cpp
+new file mode 100644
+index 0000000000..d9f7afc9ea
+--- /dev/null
++++ b/test/Sema/templight-default-template-arg.cpp
+@@ -0,0 +1,59 @@
++// RUN: %clang_cc1 -templight-dump %s 2>&1 | FileCheck %s
++template <class T = int>
++class A {};
++
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A::T'$}}
++// CHECK: {{^kind:[ ]+DefaultTemplateArgumentChecking$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+50]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A::T'$}}
++// CHECK: {{^kind:[ ]+DefaultTemplateArgumentChecking$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+45]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+39]]{{:5'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+34]]{{:5'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+28]]{{:5'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+23]]{{:5'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+17]]{{:5'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+12]]{{:5'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+6]]{{:5'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'A<int>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-default-template-arg.cpp:}}[[@LINE+1]]{{:5'$}}
++A<> a;
+diff --git a/test/Sema/templight-exception-spec-func.cpp b/test/Sema/templight-exception-spec-func.cpp
+new file mode 100644
+index 0000000000..e1b756507a
+--- /dev/null
++++ b/test/Sema/templight-exception-spec-func.cpp
+@@ -0,0 +1,63 @@
++// RUN: %clang_cc1 -templight-dump -std=c++14 %s 2>&1 | FileCheck %s
++template <bool B>
++void f() noexcept(B) {}
++
++int main()
++{
++
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+50]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+45]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+39]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+34]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<false>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+28]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<false>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+23]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<false>'$}}
++// CHECK: {{^kind:[ ]+ExceptionSpecInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+17]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<false>'$}}
++// CHECK: {{^kind:[ ]+ExceptionSpecInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+12]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<false>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+6]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<false>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-exception-spec-func.cpp:}}[[@LINE+1]]{{:3'$}}
++  f<false>();
++}
+diff --git a/test/Sema/templight-explicit-template-arg.cpp b/test/Sema/templight-explicit-template-arg.cpp
+new file mode 100644
+index 0000000000..050ec51757
+--- /dev/null
++++ b/test/Sema/templight-explicit-template-arg.cpp
+@@ -0,0 +1,51 @@
++// RUN: %clang_cc1 -templight-dump %s 2>&1 | FileCheck %s
++template <class T>
++void f(){}
++
++int main()
++{
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+39]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+34]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+28]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+f$}}
++// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+23]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+17]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+12]]{{:3'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+6]]{{:3'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'f<int>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-explicit-template-arg.cpp:}}[[@LINE+1]]{{:3'$}}
++  f<int>();
++}
 diff --git a/test/Sema/templight-memoization.cpp b/test/Sema/templight-memoization.cpp
 new file mode 100644
 index 0000000000..95957eb509
@@ -913,6 +1293,74 @@ index 0000000000..43d817d6fd
 +// CHECK: {{^event:[ ]+End$}}
 +// CHECK: {{^poi:[ ]+'.*templight-one-instantiation.cpp:}}[[@LINE+1]]{{:10'$}}
 +foo<int> x;
+diff --git a/test/Sema/templight-prior-template-arg.cpp b/test/Sema/templight-prior-template-arg.cpp
+new file mode 100644
+index 0000000000..056cc4785b
+--- /dev/null
++++ b/test/Sema/templight-prior-template-arg.cpp
+@@ -0,0 +1,62 @@
++// RUN: %clang_cc1 -templight-dump %s 2>&1 | FileCheck %s
++template<class T>
++class A {};
++
++template <template <class Inner> class Outer>
++class B {};
++
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B::Outer'$}}
++// CHECK: {{^kind:[ ]+PriorTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+50]]{{:1'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B::Outer'$}}
++// CHECK: {{^kind:[ ]+PriorTemplateArgumentSubstitution$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+45]]{{:1'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+39]]{{:6'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+34]]{{:6'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+28]]{{:6'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+TemplateInstantiation$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+23]]{{:6'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+17]]{{:6'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+12]]{{:6'$}}
++//
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+Begin$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+6]]{{:6'$}}
++// CHECK-LABEL: {{^---$}}
++// CHECK: {{^name:[ ]+'B<A>'$}}
++// CHECK: {{^kind:[ ]+Memoization$}}
++// CHECK: {{^event:[ ]+End$}}
++// CHECK: {{^poi:[ ]+'.*templight-prior-template-arg.cpp:}}[[@LINE+1]]{{:6'$}}
++B<A> b;
 diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
 index b0c97f0f1e..86564f217f 100644
 --- a/tools/CMakeLists.txt


### PR DESCRIPTION
Note that 'DeclaringSpecialMember' and 'DefiningSynthesizedFunction'
types are still not handled, because I believe they can't be printed out
without modifying clang's code further. Will need to take a deeper look
into that.
Clang SVN: https://llvm.org/svn/llvm-project/cfe/trunk@305745,
Clang git: de5743d6575952920b5938b9ed7269cd20f5bc23