### PR TITLE
Force flush of output before reading input during debugging

### DIFF
--- a/TemplightDebugger.cpp
+++ b/TemplightDebugger.cpp
@@ -674,6 +674,7 @@ public:
     std::string user_in;
     while(true) {
       llvm::outs() << "(tdb) ";
+      llvm::outs().flush();
       getLineFromStdIn(user_in);
       if ( user_in == "" )
         user_in = LastUserCommand;


### PR DESCRIPTION
Without this, the llvm::outs() output is buffered, and does not show, which makes the debugger look like it's not doing anything or hung (at least on Windows).