### PR TITLE
Added a templight-profile tag for timestamps

### DIFF
--- a/templight_clang_patch.diff
+++ b/templight_clang_patch.diff
@@ -1,0 +1,168 @@
+diff --git a/include/clang/Driver/CC1Options.td b/include/clang/Driver/CC1Options.td
+index f867218..a84c0c8 100644
+--- a/include/clang/Driver/CC1Options.td
++++ b/include/clang/Driver/CC1Options.td
+@@ -503,6 +503,8 @@ def ftest_module_file_extension_EQ :
+            "The argument is parsed as blockname:major:minor:hashed:user info">;
+ def fconcepts_ts : Flag<["-"], "fconcepts-ts">,
+   HelpText<"Enable C++ Extensions for Concepts.">;
++def templight_profile : Flag<["-"], "templight-profile">,
++  HelpText<"Add timestamps to the templight-dump output">;
+ 
+ let Group = Action_Group in {
+ 
+diff --git a/include/clang/Frontend/FrontendOptions.h b/include/clang/Frontend/FrontendOptions.h
+index c609500..af3a22b 100644
+--- a/include/clang/Frontend/FrontendOptions.h
++++ b/include/clang/Frontend/FrontendOptions.h
+@@ -52,13 +52,13 @@ namespace frontend {
+     ParseSyntaxOnly,        ///< Parse and perform semantic analysis.
+     PluginAction,           ///< Run a plugin action, \see ActionName.
+     PrintDeclContext,       ///< Print DeclContext and their Decls.
+-    PrintPreamble,          ///< Print the "preamble" of the input file
++    PrintPreamble,          ///< Print the "preamble" of the input file.
+     PrintPreprocessedInput, ///< -E mode.
+     RewriteMacros,          ///< Expand macros but not \#includes.
+     RewriteObjC,            ///< ObjC->C Rewriter.
+-    RewriteTest,            ///< Rewriter playground
++    RewriteTest,            ///< Rewriter playground.
+     RunAnalysis,            ///< Run one or more source code analyses.
+-    TemplightDump,          ///< Dump template instantiations
++    TemplightDump,          ///< Dump template instantiations.
+     MigrateSource,          ///< Run migrator.
+     RunPreprocessorOnly     ///< Just lex, no output.
+   };
+@@ -206,6 +206,9 @@ public:
+                                            ///< files into the PCM file.
+   unsigned IncludeTimestamps : 1;          ///< Whether timestamps should be
+                                            ///< written to the produced PCH file.
++  unsigned TemplightProfile : 1;           ///< Whether to add additional
++                                           ///< information to Templight dumps.
++
+ 
+   CodeCompleteOptions CodeCompleteOpts;
+ 
+@@ -337,7 +340,7 @@ public:
+     SkipFunctionBodies(false), UseGlobalModuleIndex(true),
+     GenerateGlobalModuleIndex(true), ASTDumpDecls(false), ASTDumpLookups(false),
+     BuildingImplicitModule(false), ModulesEmbedAllFiles(false),
+-    IncludeTimestamps(true), ARCMTAction(ARCMT_None),
++    IncludeTimestamps(true), TemplightProfile(false), ARCMTAction(ARCMT_None),
+     ObjCMTAction(ObjCMT_None), ProgramAction(frontend::ParseSyntaxOnly)
+   {}
+ 
+diff --git a/lib/Frontend/CompilerInvocation.cpp b/lib/Frontend/CompilerInvocation.cpp
+index 3bdc116..571928a 100644
+--- a/lib/Frontend/CompilerInvocation.cpp
++++ b/lib/Frontend/CompilerInvocation.cpp
+@@ -1449,6 +1449,7 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
+   Opts.ModulesEmbedFiles = Args.getAllArgValues(OPT_fmodules_embed_file_EQ);
+   Opts.ModulesEmbedAllFiles = Args.hasArg(OPT_fmodules_embed_all_files);
+   Opts.IncludeTimestamps = !Args.hasArg(OPT_fno_pch_timestamp);
++  Opts.TemplightProfile = Args.hasArg(OPT_templight_profile);
+ 
+   Opts.CodeCompleteOpts.IncludeMacros
+     = Args.hasArg(OPT_code_completion_macros);
+diff --git a/lib/Frontend/FrontendActions.cpp b/lib/Frontend/FrontendActions.cpp
+index 1eff566..505faf5 100644
+--- a/lib/Frontend/FrontendActions.cpp
++++ b/lib/Frontend/FrontendActions.cpp
+@@ -26,6 +26,7 @@
+ #include "llvm/Support/Path.h"
+ #include "llvm/Support/raw_ostream.h"
+ #include "llvm/Support/YAMLTraits.h"
++#include <chrono>
+ #include <memory>
+ #include <system_error>
+ 
+@@ -287,19 +288,14 @@ struct TemplightEntry {
+   std::string Event;
+   std::string DefinitionLocation;
+   std::string PointOfInstantiation;
++  std::chrono::high_resolution_clock::rep TimeStamp;
+ };
+ } // namespace
+ 
+ namespace llvm {
+ namespace yaml {
+ template <> struct MappingTraits<TemplightEntry> {
+-  static void mapping(IO &io, TemplightEntry &fields) {
+-    io.mapRequired("name", fields.Name);
+-    io.mapRequired("kind", fields.Kind);
+-    io.mapRequired("event", fields.Event);
+-    io.mapRequired("orig", fields.DefinitionLocation);
+-    io.mapRequired("poi", fields.PointOfInstantiation);
+-  }
++  static void mapping(IO &io, TemplightEntry &fields);
+ };
+ } // namespace yaml
+ } // namespace llvm
+@@ -322,8 +318,19 @@ public:
+                      const CodeSynthesisContext &Inst) override {
+     displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
+   }
++  
++  static void enableProfiling() {
++    IsProfilingEnabled = true;
++  }
++  static bool isProfilingEnabled() {
++    return IsProfilingEnabled;
++  }
++  static const std::chrono::time_point<std::chrono::high_resolution_clock> start;
+ 
+ private:
++
++  static bool IsProfilingEnabled;
++  
+   static std::string toString(CodeSynthesisContext::SynthesisKind Kind) {
+     switch (Kind) {
+     case CodeSynthesisContext::TemplateInstantiation:
+@@ -371,6 +378,10 @@ private:
+   static TemplightEntry getTemplightEntry(const Sema &TheSema,
+                                           const CodeSynthesisContext &Inst) {
+     TemplightEntry Entry;
++    if (IsProfilingEnabled){
++      auto end = std::chrono::high_resolution_clock::now();
++      Entry.TimeStamp = std::chrono::nanoseconds(end-start).count();
++    }
+     Entry.Kind = toString(Inst.Kind);
+     Entry.Event = BeginInstantiation ? "Begin" : "End";
+     if (auto *NamedTemplate = dyn_cast_or_null<NamedDecl>(Inst.Entity)) {
+@@ -393,8 +404,28 @@ private:
+     return Entry;
+   }
+ };
++
++bool DefaultTemplateInstCallback::IsProfilingEnabled = false;
++const std::chrono::time_point<std::chrono::high_resolution_clock> 
++  DefaultTemplateInstCallback::start = std::chrono::high_resolution_clock::now();
++
+ } // namespace
+ 
++namespace llvm {
++namespace yaml {
++void MappingTraits<TemplightEntry>::mapping(IO &io, TemplightEntry &fields)
++{
++  io.mapRequired("name", fields.Name);
++  io.mapRequired("kind", fields.Kind);
++  io.mapRequired("event", fields.Event);
++  io.mapRequired("orig", fields.DefinitionLocation);
++  io.mapRequired("poi", fields.PointOfInstantiation);
++  if(DefaultTemplateInstCallback::isProfilingEnabled())
++    io.mapRequired("stamp", fields.TimeStamp);
++}
++} // namespace yaml
++} // namespace llvm
++
+ std::unique_ptr<ASTConsumer>
+ TemplightDumpAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return llvm::make_unique<ASTConsumer>();
+@@ -411,6 +442,8 @@ void TemplightDumpAction::ExecuteAction() {
+ 
+   CI.getSema().TemplateInstCallbacks.push_back(
+       llvm::make_unique<DefaultTemplateInstCallback>());
++  if(CI.getFrontendOpts().TemplightProfile)
++    DefaultTemplateInstCallback::enableProfiling();
+   ASTFrontendAction::ExecuteAction();
+ }
+ 

--- a/templight_clang_patch.diff
+++ b/templight_clang_patch.diff
@@ -64,7 +64,7 @@ index 23f3c8f..2259c94 100644
    Opts.CodeCompleteOpts.IncludeMacros
      = Args.hasArg(OPT_code_completion_macros);
 diff --git a/lib/Frontend/FrontendActions.cpp b/lib/Frontend/FrontendActions.cpp
-index 1eff566..6340a93 100644
+index 1eff566..1656095 100644
 --- a/lib/Frontend/FrontendActions.cpp
 +++ b/lib/Frontend/FrontendActions.cpp
 @@ -26,6 +26,7 @@
@@ -103,8 +103,8 @@ index 1eff566..6340a93 100644
  
 -  void finalize(const Sema &) override {}
 +  void finalize(const Sema &) override {
-+    if(IsProfilingEnabled)
-+      for(auto &Entry : TemplightEntries)
++    if(isProfilingEnabled())
++      for(auto &Entry : *TemplightEntries)
 +        displayTemplightEntry(llvm::outs(), Entry);
 +  }
  
@@ -113,8 +113,8 @@ index 1eff566..6340a93 100644
 -    displayTemplightEntry<true>(llvm::outs(), TheSema, Inst);
 +    TemplightEntry Entry = getTemplightEntry<true>(TheSema, Inst);
 +
-+    if(IsProfilingEnabled)
-+      TemplightEntries.push_back(std::move(Entry));
++    if(isProfilingEnabled())
++      TemplightEntries->push_back(std::move(Entry));
 +    else
 +      displayTemplightEntry(llvm::outs(), Entry);
    }
@@ -124,25 +124,25 @@ index 1eff566..6340a93 100644
 -    displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
 +    TemplightEntry Entry = getTemplightEntry<false>(TheSema, Inst);
 +
-+    if(IsProfilingEnabled)
-+      TemplightEntries.push_back(std::move(Entry));
++    if(isProfilingEnabled())
++      TemplightEntries->push_back(std::move(Entry));
 +    else
 +      displayTemplightEntry(llvm::outs(), Entry);
 +  }
 +  
 +  void enableProfiling() {
-+    IsProfilingEnabled = true;
++    TemplightEntries = std::vector<TemplightEntry>();
    }
++  
 +  bool isProfilingEnabled() {
-+    return IsProfilingEnabled;
++    return TemplightEntries.hasValue();
 +  }
 +
 +  static const std::chrono::time_point<std::chrono::high_resolution_clock> start;
  
  private:
 +
-+  bool IsProfilingEnabled = false;
-+  std::vector<TemplightEntry> TemplightEntries;
++  Optional<std::vector<TemplightEntry>> TemplightEntries = None;
 +  
    static std::string toString(CodeSynthesisContext::SynthesisKind Kind) {
      switch (Kind) {
@@ -173,7 +173,7 @@ index 1eff566..6340a93 100644
 +  TemplightEntry getTemplightEntry(const Sema &TheSema,
                                            const CodeSynthesisContext &Inst) {
      TemplightEntry Entry;
-+    if (IsProfilingEnabled){
++    if (isProfilingEnabled()){
 +      auto end = std::chrono::high_resolution_clock::now();
 +      Entry.TimeStamp = std::chrono::nanoseconds(end-start).count();
 +    }
@@ -222,12 +222,3 @@ index 1eff566..6340a93 100644
    ASTFrontendAction::ExecuteAction();
  }
  
-diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
-index 9f76d36..541a2b7 100644
---- a/tools/CMakeLists.txt
-+++ b/tools/CMakeLists.txt
-@@ -35,3 +35,4 @@ add_llvm_external_project(clang-tools-extra extra)
- 
- # libclang may require clang-tidy in clang-tools-extra.
- add_clang_subdirectory(libclang)
-+add_clang_subdirectory(templight)

--- a/templight_clang_patch.diff
+++ b/templight_clang_patch.diff
@@ -1,5 +1,5 @@
 diff --git a/include/clang/Driver/CC1Options.td b/include/clang/Driver/CC1Options.td
-index f867218..a84c0c8 100644
+index 97c996d..e0b6e6f 100644
 --- a/include/clang/Driver/CC1Options.td
 +++ b/include/clang/Driver/CC1Options.td
 @@ -503,6 +503,8 @@ def ftest_module_file_extension_EQ :
@@ -52,10 +52,10 @@ index c609500..af3a22b 100644
    {}
  
 diff --git a/lib/Frontend/CompilerInvocation.cpp b/lib/Frontend/CompilerInvocation.cpp
-index 3bdc116..571928a 100644
+index 23f3c8f..2259c94 100644
 --- a/lib/Frontend/CompilerInvocation.cpp
 +++ b/lib/Frontend/CompilerInvocation.cpp
-@@ -1449,6 +1449,7 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
+@@ -1460,6 +1460,7 @@ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
    Opts.ModulesEmbedFiles = Args.getAllArgValues(OPT_fmodules_embed_file_EQ);
    Opts.ModulesEmbedAllFiles = Args.hasArg(OPT_fmodules_embed_all_files);
    Opts.IncludeTimestamps = !Args.hasArg(OPT_fno_pch_timestamp);
@@ -64,7 +64,7 @@ index 3bdc116..571928a 100644
    Opts.CodeCompleteOpts.IncludeMacros
      = Args.hasArg(OPT_code_completion_macros);
 diff --git a/lib/Frontend/FrontendActions.cpp b/lib/Frontend/FrontendActions.cpp
-index 1eff566..505faf5 100644
+index 1eff566..6340a93 100644
 --- a/lib/Frontend/FrontendActions.cpp
 +++ b/lib/Frontend/FrontendActions.cpp
 @@ -26,6 +26,7 @@
@@ -79,7 +79,7 @@ index 1eff566..505faf5 100644
    std::string Event;
    std::string DefinitionLocation;
    std::string PointOfInstantiation;
-+  std::chrono::high_resolution_clock::rep TimeStamp;
++  Optional<std::chrono::high_resolution_clock::rep> TimeStamp;
  };
  } // namespace
  
@@ -97,28 +97,80 @@ index 1eff566..505faf5 100644
  };
  } // namespace yaml
  } // namespace llvm
-@@ -322,8 +318,19 @@ public:
-                      const CodeSynthesisContext &Inst) override {
-     displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
-   }
-+  
-+  static void enableProfiling() {
-+    IsProfilingEnabled = true;
+@@ -311,19 +307,46 @@ class DefaultTemplateInstCallback : public TemplateInstantiationCallback {
+ public:
+   void initialize(const Sema &) override {}
+ 
+-  void finalize(const Sema &) override {}
++  void finalize(const Sema &) override {
++    if(IsProfilingEnabled)
++      for(auto &Entry : TemplightEntries)
++        displayTemplightEntry(llvm::outs(), Entry);
 +  }
-+  static bool isProfilingEnabled() {
+ 
+   void atTemplateBegin(const Sema &TheSema,
+                        const CodeSynthesisContext &Inst) override {
+-    displayTemplightEntry<true>(llvm::outs(), TheSema, Inst);
++    TemplightEntry Entry = getTemplightEntry<true>(TheSema, Inst);
++
++    if(IsProfilingEnabled)
++      TemplightEntries.push_back(std::move(Entry));
++    else
++      displayTemplightEntry(llvm::outs(), Entry);
+   }
+ 
+   void atTemplateEnd(const Sema &TheSema,
+                      const CodeSynthesisContext &Inst) override {
+-    displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
++    TemplightEntry Entry = getTemplightEntry<false>(TheSema, Inst);
++
++    if(IsProfilingEnabled)
++      TemplightEntries.push_back(std::move(Entry));
++    else
++      displayTemplightEntry(llvm::outs(), Entry);
++  }
++  
++  void enableProfiling() {
++    IsProfilingEnabled = true;
+   }
++  bool isProfilingEnabled() {
 +    return IsProfilingEnabled;
 +  }
++
 +  static const std::chrono::time_point<std::chrono::high_resolution_clock> start;
  
  private:
 +
-+  static bool IsProfilingEnabled;
++  bool IsProfilingEnabled = false;
++  std::vector<TemplightEntry> TemplightEntries;
 +  
    static std::string toString(CodeSynthesisContext::SynthesisKind Kind) {
      switch (Kind) {
      case CodeSynthesisContext::TemplateInstantiation:
-@@ -371,6 +378,10 @@ private:
-   static TemplightEntry getTemplightEntry(const Sema &TheSema,
+@@ -352,15 +375,12 @@ private:
+     return "";
+   }
+ 
+-  template <bool BeginInstantiation>
+-  static void displayTemplightEntry(llvm::raw_ostream &Out, const Sema &TheSema,
+-                                    const CodeSynthesisContext &Inst) {
++  void displayTemplightEntry(llvm::raw_ostream &Out, 
++                                              TemplightEntry& Entry) {
+     std::string YAML;
+     {
+       llvm::raw_string_ostream OS(YAML);
+       llvm::yaml::Output YO(OS);
+-      TemplightEntry Entry =
+-          getTemplightEntry<BeginInstantiation>(TheSema, Inst);
+       llvm::yaml::EmptyContext Context;
+       llvm::yaml::yamlize(YO, Entry, true, Context);
+     }
+@@ -368,9 +388,13 @@ private:
+   }
+ 
+   template <bool BeginInstantiation>
+-  static TemplightEntry getTemplightEntry(const Sema &TheSema,
++  TemplightEntry getTemplightEntry(const Sema &TheSema,
                                            const CodeSynthesisContext &Inst) {
      TemplightEntry Entry;
 +    if (IsProfilingEnabled){
@@ -128,12 +180,11 @@ index 1eff566..505faf5 100644
      Entry.Kind = toString(Inst.Kind);
      Entry.Event = BeginInstantiation ? "Begin" : "End";
      if (auto *NamedTemplate = dyn_cast_or_null<NamedDecl>(Inst.Entity)) {
-@@ -393,8 +404,28 @@ private:
+@@ -393,8 +417,27 @@ private:
      return Entry;
    }
  };
 +
-+bool DefaultTemplateInstCallback::IsProfilingEnabled = false;
 +const std::chrono::time_point<std::chrono::high_resolution_clock> 
 +  DefaultTemplateInstCallback::start = std::chrono::high_resolution_clock::now();
 +
@@ -148,8 +199,8 @@ index 1eff566..505faf5 100644
 +  io.mapRequired("event", fields.Event);
 +  io.mapRequired("orig", fields.DefinitionLocation);
 +  io.mapRequired("poi", fields.PointOfInstantiation);
-+  if(DefaultTemplateInstCallback::isProfilingEnabled())
-+    io.mapRequired("stamp", fields.TimeStamp);
++  if(fields.TimeStamp)
++    io.mapRequired("stamp", fields.TimeStamp.getValue());
 +}
 +} // namespace yaml
 +} // namespace llvm
@@ -157,12 +208,26 @@ index 1eff566..505faf5 100644
  std::unique_ptr<ASTConsumer>
  TemplightDumpAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
    return llvm::make_unique<ASTConsumer>();
-@@ -411,6 +442,8 @@ void TemplightDumpAction::ExecuteAction() {
+@@ -409,8 +452,11 @@ void TemplightDumpAction::ExecuteAction() {
+   // here so the source manager would be initialized.
+   EnsureSemaIsCreated(CI, *this);
  
-   CI.getSema().TemplateInstCallbacks.push_back(
-       llvm::make_unique<DefaultTemplateInstCallback>());
+-  CI.getSema().TemplateInstCallbacks.push_back(
+-      llvm::make_unique<DefaultTemplateInstCallback>());
++  auto D = llvm::make_unique<DefaultTemplateInstCallback>();
 +  if(CI.getFrontendOpts().TemplightProfile)
-+    DefaultTemplateInstCallback::enableProfiling();
++    D->enableProfiling();
++  
++  CI.getSema().TemplateInstCallbacks.push_back(std::move(D));
    ASTFrontendAction::ExecuteAction();
  }
  
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 9f76d36..541a2b7 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -35,3 +35,4 @@ add_llvm_external_project(clang-tools-extra extra)
+ 
+ # libclang may require clang-tidy in clang-tools-extra.
+ add_clang_subdirectory(libclang)
++add_clang_subdirectory(templight)

--- a/templight_clang_patch_with_context.diff
+++ b/templight_clang_patch_with_context.diff
@@ -1,0 +1,5077 @@
+diff --git a/include/clang/Driver/CC1Options.td b/include/clang/Driver/CC1Options.td
+index f867218..a84c0c8 100644
+--- a/include/clang/Driver/CC1Options.td
++++ b/include/clang/Driver/CC1Options.td
+@@ -1,843 +1,845 @@
+ //===--- CC1Options.td - Options for clang -cc1 ---------------------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+ //
+ // This file is distributed under the University of Illinois Open Source
+ // License. See LICENSE.TXT for details.
+ //
+ //===----------------------------------------------------------------------===//
+ //
+ //  This file defines the options accepted by clang -cc1 and clang -cc1as.
+ //
+ //===----------------------------------------------------------------------===//
+ 
+ let Flags = [CC1Option, NoDriverOption] in {
+ 
+ //===----------------------------------------------------------------------===//
+ // Target Options
+ //===----------------------------------------------------------------------===//
+ 
+ let Flags = [CC1Option, CC1AsOption, NoDriverOption] in {
+ 
+ def target_cpu : Separate<["-"], "target-cpu">,
+   HelpText<"Target a specific cpu type">;
+ def target_feature : Separate<["-"], "target-feature">,
+   HelpText<"Target specific attributes">;
+ def triple : Separate<["-"], "triple">,
+   HelpText<"Specify target triple (e.g. i686-apple-darwin9)">;
+ def target_abi : Separate<["-"], "target-abi">,
+   HelpText<"Target a particular ABI type">;
+ 
+ }
+ 
+ def target_linker_version : Separate<["-"], "target-linker-version">,
+   HelpText<"Target linker version">;
+ def triple_EQ : Joined<["-"], "triple=">, Alias<triple>;
+ def mfpmath : Separate<["-"], "mfpmath">,
+   HelpText<"Which unit to use for fp math">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Analyzer Options
+ //===----------------------------------------------------------------------===//
+ 
+ def analysis_UnoptimizedCFG : Flag<["-"], "unoptimized-cfg">,
+   HelpText<"Generate unoptimized CFGs for all analyses">;
+ def analysis_CFGAddImplicitDtors : Flag<["-"], "cfg-add-implicit-dtors">,
+   HelpText<"Add C++ implicit destructors to CFGs for all analyses">;
+ 
+ def analyzer_store : Separate<["-"], "analyzer-store">,
+   HelpText<"Source Code Analysis - Abstract Memory Store Models">;
+ def analyzer_store_EQ : Joined<["-"], "analyzer-store=">, Alias<analyzer_store>;
+ 
+ def analyzer_constraints : Separate<["-"], "analyzer-constraints">,
+   HelpText<"Source Code Analysis - Symbolic Constraint Engines">;
+ def analyzer_constraints_EQ : Joined<["-"], "analyzer-constraints=">,
+   Alias<analyzer_constraints>;
+ 
+ def analyzer_output : Separate<["-"], "analyzer-output">,
+   HelpText<"Source Code Analysis - Output Options">;
+ def analyzer_output_EQ : Joined<["-"], "analyzer-output=">,
+   Alias<analyzer_output>;
+ 
+ def analyzer_purge : Separate<["-"], "analyzer-purge">,
+   HelpText<"Source Code Analysis - Dead Symbol Removal Frequency">;
+ def analyzer_purge_EQ : Joined<["-"], "analyzer-purge=">, Alias<analyzer_purge>;
+ 
+ def analyzer_opt_analyze_headers : Flag<["-"], "analyzer-opt-analyze-headers">,
+   HelpText<"Force the static analyzer to analyze functions defined in header files">;
+ def analyzer_opt_analyze_nested_blocks : Flag<["-"], "analyzer-opt-analyze-nested-blocks">,
+   HelpText<"Analyze the definitions of blocks in addition to functions">;
+ def analyzer_display_progress : Flag<["-"], "analyzer-display-progress">,
+   HelpText<"Emit verbose output about the analyzer's progress">;
+ def analyze_function : Separate<["-"], "analyze-function">,
+   HelpText<"Run analysis on specific function (for C++ include parameters in name)">;
+ def analyze_function_EQ : Joined<["-"], "analyze-function=">, Alias<analyze_function>;
+ def analyzer_eagerly_assume : Flag<["-"], "analyzer-eagerly-assume">,
+   HelpText<"Eagerly assume the truth/falseness of some symbolic constraints">;
+ def trim_egraph : Flag<["-"], "trim-egraph">,
+   HelpText<"Only show error-related paths in the analysis graph">;
+ def analyzer_viz_egraph_graphviz : Flag<["-"], "analyzer-viz-egraph-graphviz">,
+   HelpText<"Display exploded graph using GraphViz">;
+ def analyzer_viz_egraph_ubigraph : Flag<["-"], "analyzer-viz-egraph-ubigraph">,
+   HelpText<"Display exploded graph using Ubigraph">;
+ 
+ def analyzer_inline_max_stack_depth : Separate<["-"], "analyzer-inline-max-stack-depth">,
+   HelpText<"Bound on stack depth while inlining (4 by default)">;
+ def analyzer_inline_max_stack_depth_EQ : Joined<["-"], "analyzer-inline-max-stack-depth=">, 
+   Alias<analyzer_inline_max_stack_depth>;
+   
+ def analyzer_inlining_mode : Separate<["-"], "analyzer-inlining-mode">,
+   HelpText<"Specify the function selection heuristic used during inlining">;
+ def analyzer_inlining_mode_EQ : Joined<["-"], "analyzer-inlining-mode=">, Alias<analyzer_inlining_mode>;
+ 
+ def analyzer_disable_retry_exhausted : Flag<["-"], "analyzer-disable-retry-exhausted">,
+   HelpText<"Do not re-analyze paths leading to exhausted nodes with a different strategy (may decrease code coverage)">;
+   
+ def analyzer_max_loop : Separate<["-"], "analyzer-max-loop">,
+   HelpText<"The maximum number of times the analyzer will go through a loop">;
+ def analyzer_stats : Flag<["-"], "analyzer-stats">,
+   HelpText<"Print internal analyzer statistics.">;
+ 
+ def analyzer_checker : Separate<["-"], "analyzer-checker">,
+   HelpText<"Choose analyzer checkers to enable">,
+   ValuesCode<[{
+     const char *Values =
+     #define GET_CHECKERS
+     #define CHECKER(FULLNAME, CLASS, DESCFILE, HT, G, H)  FULLNAME ","
+     #include "clang/StaticAnalyzer/Checkers/Checkers.inc"
+     #undef GET_CHECKERS
+     #define GET_PACKAGES
+     #define PACKAGE(FULLNAME, G, D)  FULLNAME ","
+     #include "clang/StaticAnalyzer/Checkers/Checkers.inc"
+     #undef GET_PACKAGES
+     ;
+   }]>;
+ def analyzer_checker_EQ : Joined<["-"], "analyzer-checker=">,
+   Alias<analyzer_checker>;
+ 
+ def analyzer_disable_checker : Separate<["-"], "analyzer-disable-checker">,
+   HelpText<"Choose analyzer checkers to disable">;
+ def analyzer_disable_checker_EQ : Joined<["-"], "analyzer-disable-checker=">,
+   Alias<analyzer_disable_checker>;
+ 
+ def analyzer_disable_all_checks : Flag<["-"], "analyzer-disable-all-checks">,
+   HelpText<"Disable all static analyzer checks">;
+ 
+ def analyzer_checker_help : Flag<["-"], "analyzer-checker-help">,
+   HelpText<"Display the list of analyzer checkers that are available">;
+ 
+ def analyzer_list_enabled_checkers : Flag<["-"], "analyzer-list-enabled-checkers">,
+   HelpText<"Display the list of enabled analyzer checkers">;
+ 
+ def analyzer_config : Separate<["-"], "analyzer-config">,
+   HelpText<"Choose analyzer options to enable">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Migrator Options
+ //===----------------------------------------------------------------------===//
+ def migrator_no_nsalloc_error : Flag<["-"], "no-ns-alloc-error">,
+   HelpText<"Do not error on use of NSAllocateCollectable/NSReallocateCollectable">;
+ 
+ def migrator_no_finalize_removal : Flag<["-"], "no-finalize-removal">,
+   HelpText<"Do not remove finalize method in gc mode">;
+ 
+ //===----------------------------------------------------------------------===//
+ // CodeGen Options
+ //===----------------------------------------------------------------------===//
+ 
+ let Flags = [CC1Option, CC1AsOption, NoDriverOption] in {
+ def debug_info_kind_EQ : Joined<["-"], "debug-info-kind=">;
+ def debug_info_macro : Flag<["-"], "debug-info-macro">,
+   HelpText<"Emit macro debug information">;
+ def dwarf_version_EQ : Joined<["-"], "dwarf-version=">;
+ def debugger_tuning_EQ : Joined<["-"], "debugger-tuning=">;
+ def fdebug_compilation_dir : Separate<["-"], "fdebug-compilation-dir">,
+   HelpText<"The compilation directory to embed in the debug info.">;
+ def dwarf_debug_flags : Separate<["-"], "dwarf-debug-flags">,
+   HelpText<"The string to embed in the Dwarf debug flags record.">;
+ def compress_debug_sections : Flag<["-", "--"], "compress-debug-sections">,
+     HelpText<"DWARF debug sections compression">;
+ def compress_debug_sections_EQ : Joined<["-"], "compress-debug-sections=">,
+     HelpText<"DWARF debug sections compression type">;
+ def mno_exec_stack : Flag<["-"], "mnoexecstack">,
+   HelpText<"Mark the file as not needing an executable stack">;
+ def massembler_fatal_warnings : Flag<["-"], "massembler-fatal-warnings">,
+   HelpText<"Make assembler warnings fatal">;
+ def mrelax_relocations : Flag<["--"], "mrelax-relocations">,
+     HelpText<"Use relaxable elf relocations">;
+ def msave_temp_labels : Flag<["-"], "msave-temp-labels">,
+   HelpText<"Save temporary labels in the symbol table. "
+            "Note this may change .s semantics and shouldn't generally be used "
+            "on compiler-generated code.">;
+ def mrelocation_model : Separate<["-"], "mrelocation-model">,
+   HelpText<"The relocation model to use">, Values<"static,pic,ropi,rwpi,ropi-rwpi,dynamic-no-pic">;
+ def fno_math_builtin : Flag<["-"], "fno-math-builtin">,
+   HelpText<"Disable implicit builtin knowledge of math functions">;
+ }
+ 
+ def disable_llvm_verifier : Flag<["-"], "disable-llvm-verifier">,
+   HelpText<"Don't run the LLVM IR verifier pass">;
+ def disable_llvm_passes : Flag<["-"], "disable-llvm-passes">,
+   HelpText<"Use together with -emit-llvm to get pristine LLVM IR from the "
+            "frontend by not running any LLVM passes at all">;
+ def disable_llvm_optzns : Flag<["-"], "disable-llvm-optzns">,
+   Alias<disable_llvm_passes>;
+ def disable_lifetimemarkers : Flag<["-"], "disable-lifetime-markers">,
+   HelpText<"Disable lifetime-markers emission even when optimizations are "
+            "enabled">;
+ def disable_O0_optnone : Flag<["-"], "disable-O0-optnone">,
+   HelpText<"Disable adding the optnone attribute to functions at O0">;
+ def disable_red_zone : Flag<["-"], "disable-red-zone">,
+   HelpText<"Do not emit code that uses the red zone.">;
+ def dwarf_column_info : Flag<["-"], "dwarf-column-info">,
+   HelpText<"Turn on column location information.">;
+ def split_dwarf : Flag<["-"], "split-dwarf">,
+   HelpText<"Split out the dwarf .dwo sections">;
+ def gnu_pubnames : Flag<["-"], "gnu-pubnames">,
+   HelpText<"Emit newer GNU style pubnames">;
+ def arange_sections : Flag<["-"], "arange_sections">,
+   HelpText<"Emit DWARF .debug_arange sections">;
+ def dwarf_ext_refs : Flag<["-"], "dwarf-ext-refs">,
+   HelpText<"Generate debug info with external references to clang modules"
+            " or precompiled headers">;
+ def dwarf_explicit_import : Flag<["-"], "dwarf-explicit-import">,
+   HelpText<"Generate explicit import from anonymous namespace to containing"
+            " scope">;
+ def debug_forward_template_params : Flag<["-"], "debug-forward-template-params">,
+   HelpText<"Emit complete descriptions of template parameters in forward"
+            " declarations">;
+ def fforbid_guard_variables : Flag<["-"], "fforbid-guard-variables">,
+   HelpText<"Emit an error if a C++ static local initializer would need a guard variable">;
+ def no_implicit_float : Flag<["-"], "no-implicit-float">,
+   HelpText<"Don't generate implicit floating point instructions">;
+ def fdump_vtable_layouts : Flag<["-"], "fdump-vtable-layouts">,
+   HelpText<"Dump the layouts of all vtables that will be emitted in a translation unit">;
+ def fmerge_functions : Flag<["-"], "fmerge-functions">,
+   HelpText<"Permit merging of identical functions when optimizing.">;
+ def femit_coverage_notes : Flag<["-"], "femit-coverage-notes">,
+   HelpText<"Emit a gcov coverage notes file when compiling.">;
+ def femit_coverage_data: Flag<["-"], "femit-coverage-data">,
+   HelpText<"Instrument the program to emit gcov coverage data when run.">;
+ def coverage_data_file : Separate<["-"], "coverage-data-file">,
+   HelpText<"Emit coverage data to this filename.">;
+ def coverage_data_file_EQ : Joined<["-"], "coverage-data-file=">,
+   Alias<coverage_data_file>;
+ def coverage_notes_file : Separate<["-"], "coverage-notes-file">,
+   HelpText<"Emit coverage notes to this filename.">;
+ def coverage_notes_file_EQ : Joined<["-"], "coverage-notes-file=">,
+   Alias<coverage_notes_file>;
+ def coverage_cfg_checksum : Flag<["-"], "coverage-cfg-checksum">,
+   HelpText<"Emit CFG checksum for functions in .gcno files.">;
+ def coverage_no_function_names_in_data : Flag<["-"], "coverage-no-function-names-in-data">,
+   HelpText<"Emit function names in .gcda files.">;
+ def coverage_exit_block_before_body : Flag<["-"], "coverage-exit-block-before-body">,
+   HelpText<"Emit the exit block before the body blocks in .gcno files.">;
+ def coverage_version_EQ : Joined<["-"], "coverage-version=">,
+   HelpText<"Four-byte version string for gcov files.">;
+ def test_coverage : Flag<["-"], "test-coverage">,
+   HelpText<"Do not generate coverage files or remove coverage changes from IR">;
+ def dump_coverage_mapping : Flag<["-"], "dump-coverage-mapping">,
+   HelpText<"Dump the coverage mapping records, for testing">;
+ def fuse_register_sized_bitfield_access: Flag<["-"], "fuse-register-sized-bitfield-access">,
+   HelpText<"Use register sized accesses to bit-fields, when possible.">;
+ def relaxed_aliasing : Flag<["-"], "relaxed-aliasing">,
+   HelpText<"Turn off Type Based Alias Analysis">;
+ def no_struct_path_tbaa : Flag<["-"], "no-struct-path-tbaa">,
+   HelpText<"Turn off struct-path aware Type Based Alias Analysis">;
+ def new_struct_path_tbaa : Flag<["-"], "new-struct-path-tbaa">,
+   HelpText<"Enable enhanced struct-path aware Type Based Alias Analysis">;
+ def masm_verbose : Flag<["-"], "masm-verbose">,
+   HelpText<"Generate verbose assembly output">;
+ def mcode_model : Separate<["-"], "mcode-model">,
+   HelpText<"The code model to use">, Values<"small,kernel,medium,large">;
+ def mdebug_pass : Separate<["-"], "mdebug-pass">,
+   HelpText<"Enable additional debug output">;
+ def mdisable_fp_elim : Flag<["-"], "mdisable-fp-elim">,
+   HelpText<"Disable frame pointer elimination optimization">;
+ def mdisable_tail_calls : Flag<["-"], "mdisable-tail-calls">,
+   HelpText<"Disable tail call optimization, keeping the call stack accurate">;
+ def menable_no_infinities : Flag<["-"], "menable-no-infs">,
+   HelpText<"Allow optimization to assume there are no infinities.">;
+ def menable_no_nans : Flag<["-"], "menable-no-nans">,
+   HelpText<"Allow optimization to assume there are no NaNs.">;
+ def menable_unsafe_fp_math : Flag<["-"], "menable-unsafe-fp-math">,
+   HelpText<"Allow unsafe floating-point math optimizations which may decrease "
+            "precision">;
+ def mreassociate : Flag<["-"], "mreassociate">,
+   HelpText<"Allow reassociation transformations for floating-point instructions">;
+ def mfloat_abi : Separate<["-"], "mfloat-abi">,
+   HelpText<"The float ABI to use">;
+ def mtp : Separate<["-"], "mtp">,
+   HelpText<"Mode for reading thread pointer">;
+ def mlimit_float_precision : Separate<["-"], "mlimit-float-precision">,
+   HelpText<"Limit float precision to the given value">;
+ def split_stacks : Flag<["-"], "split-stacks">,
+   HelpText<"Try to use a split stack if possible.">;
+ def mno_zero_initialized_in_bss : Flag<["-"], "mno-zero-initialized-in-bss">,
+   HelpText<"Do not put zero initialized data in the BSS">;
+ def backend_option : Separate<["-"], "backend-option">,
+   HelpText<"Additional arguments to forward to LLVM backend (during code gen)">;
+ def mregparm : Separate<["-"], "mregparm">,
+   HelpText<"Limit the number of registers available for integer arguments">;
+ def munwind_tables : Flag<["-"], "munwind-tables">,
+   HelpText<"Generate unwinding tables for all functions">;
+ def mconstructor_aliases : Flag<["-"], "mconstructor-aliases">,
+   HelpText<"Emit complete constructors and destructors as aliases when possible">;
+ def mlink_bitcode_file : Separate<["-"], "mlink-bitcode-file">,
+   HelpText<"Link the given bitcode file before performing optimizations.">;
+ def mlink_cuda_bitcode : Separate<["-"], "mlink-cuda-bitcode">,
+   HelpText<"Link and internalize needed symbols from the given bitcode file "
+            "before performing optimizations.">;
+ def vectorize_loops : Flag<["-"], "vectorize-loops">,
+   HelpText<"Run the Loop vectorization passes">;
+ def vectorize_slp : Flag<["-"], "vectorize-slp">,
+   HelpText<"Run the SLP vectorization passes">;
+ def dependent_lib : Joined<["--"], "dependent-lib=">,
+   HelpText<"Add dependent library">;
+ def linker_option : Joined<["--"], "linker-option=">,
+   HelpText<"Add linker option">;
+ def fsanitize_coverage_type : Joined<["-"], "fsanitize-coverage-type=">,
+                               HelpText<"Sanitizer coverage type">;
+ def fsanitize_coverage_indirect_calls
+     : Flag<["-"], "fsanitize-coverage-indirect-calls">,
+       HelpText<"Enable sanitizer coverage for indirect calls">;
+ def fsanitize_coverage_trace_bb
+     : Flag<["-"], "fsanitize-coverage-trace-bb">,
+       HelpText<"Enable basic block tracing in sanitizer coverage">;
+ def fsanitize_coverage_trace_cmp
+     : Flag<["-"], "fsanitize-coverage-trace-cmp">,
+       HelpText<"Enable cmp instruction tracing in sanitizer coverage">;
+ def fsanitize_coverage_trace_div
+     : Flag<["-"], "fsanitize-coverage-trace-div">,
+       HelpText<"Enable div instruction tracing in sanitizer coverage">;
+ def fsanitize_coverage_trace_gep
+     : Flag<["-"], "fsanitize-coverage-trace-gep">,
+       HelpText<"Enable gep instruction tracing in sanitizer coverage">;
+ def fsanitize_coverage_8bit_counters
+     : Flag<["-"], "fsanitize-coverage-8bit-counters">,
+       HelpText<"Enable frequency counters in sanitizer coverage">;
+ def fsanitize_coverage_inline_8bit_counters
+     : Flag<["-"], "fsanitize-coverage-inline-8bit-counters">,
+       HelpText<"Enable inline 8-bit counters in sanitizer coverage">;
+ def fsanitize_coverage_pc_table
+     : Flag<["-"], "fsanitize-coverage-pc-table">,
+       HelpText<"Create a table of coverage-instrumented PCs">;
+ def fsanitize_coverage_trace_pc
+     : Flag<["-"], "fsanitize-coverage-trace-pc">,
+       HelpText<"Enable PC tracing in sanitizer coverage">;
+ def fsanitize_coverage_trace_pc_guard
+     : Flag<["-"], "fsanitize-coverage-trace-pc-guard">,
+       HelpText<"Enable PC tracing with guard in sanitizer coverage">;
+ def fsanitize_coverage_no_prune
+     : Flag<["-"], "fsanitize-coverage-no-prune">,
+       HelpText<"Disable coverage pruning (i.e. instrument all blocks/edges)">;
+ def fsanitize_coverage_stack_depth
+     : Flag<["-"], "fsanitize-coverage-stack-depth">,
+       HelpText<"Enable max stack depth tracing">;
+ def fprofile_instrument_EQ : Joined<["-"], "fprofile-instrument=">,
+     HelpText<"Enable PGO instrumentation. The accepted value is clang, llvm, "
+              "or none">, Values<"none,clang,llvm">;
+ def fprofile_instrument_path_EQ : Joined<["-"], "fprofile-instrument-path=">,
+     HelpText<"Generate instrumented code to collect execution counts into "
+              "<file> (overridden by LLVM_PROFILE_FILE env var)">;
+ def fprofile_instrument_use_path_EQ :
+     Joined<["-"], "fprofile-instrument-use-path=">,
+     HelpText<"Specify the profile path in PGO use compilation">;
+ def flto_visibility_public_std:
+     Flag<["-"], "flto-visibility-public-std">,
+     HelpText<"Use public LTO visibility for classes in std and stdext namespaces">;
+ def flto_unit: Flag<["-"], "flto-unit">,
+     HelpText<"Emit IR to support LTO unit features (CFI, whole program vtable opt)">;
+ def fno_lto_unit: Flag<["-"], "fno-lto-unit">;
+ def fthin_link_bitcode_EQ : Joined<["-"], "fthin-link-bitcode=">,
+     HelpText<"Write minimized bitcode to <file> for the ThinLTO thin link only">;
+ def fdebug_pass_manager : Flag<["-"], "fdebug-pass-manager">,
+     HelpText<"Prints debug information for the new pass manager">;
+ def fno_debug_pass_manager : Flag<["-"], "fno-debug-pass-manager">,
+     HelpText<"Disables debug printing for the new pass manager">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Dependency Output Options
+ //===----------------------------------------------------------------------===//
+ 
+ def sys_header_deps : Flag<["-"], "sys-header-deps">,
+   HelpText<"Include system headers in dependency output">;
+ def module_file_deps : Flag<["-"], "module-file-deps">,
+   HelpText<"Include module files in dependency output">;
+ def header_include_file : Separate<["-"], "header-include-file">,
+   HelpText<"Filename (or -) to write header include output to">;
+ def show_includes : Flag<["--"], "show-includes">,
+   HelpText<"Print cl.exe style /showIncludes to stdout">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Diagnostic Options
+ //===----------------------------------------------------------------------===//
+ 
+ def diagnostic_log_file : Separate<["-"], "diagnostic-log-file">,
+   HelpText<"Filename (or -) to log diagnostics to">;
+ def diagnostic_serialized_file : Separate<["-"], "serialize-diagnostic-file">,
+   MetaVarName<"<filename>">,
+   HelpText<"File for serializing diagnostics in a binary format">;
+ 
+ def fdiagnostics_format : Separate<["-"], "fdiagnostics-format">,
+   HelpText<"Change diagnostic formatting to match IDE and command line tools">, Values<"clang,msvc,msvc-fallback,vi">;
+ def fdiagnostics_show_category : Separate<["-"], "fdiagnostics-show-category">,
+   HelpText<"Print diagnostic category">, Values<"none,id,name">;
+ def fno_diagnostics_use_presumed_location : Flag<["-"], "fno-diagnostics-use-presumed-location">,
+   HelpText<"Ignore #line directives when displaying diagnostic locations">;
+ def ftabstop : Separate<["-"], "ftabstop">, MetaVarName<"<N>">,
+   HelpText<"Set the tab stop distance.">;
+ def ferror_limit : Separate<["-"], "ferror-limit">, MetaVarName<"<N>">,
+   HelpText<"Set the maximum number of errors to emit before stopping (0 = no limit).">;
+ def fmacro_backtrace_limit : Separate<["-"], "fmacro-backtrace-limit">, MetaVarName<"<N>">,
+   HelpText<"Set the maximum number of entries to print in a macro expansion backtrace (0 = no limit).">;
+ def ftemplate_backtrace_limit : Separate<["-"], "ftemplate-backtrace-limit">, MetaVarName<"<N>">,
+   HelpText<"Set the maximum number of entries to print in a template instantiation backtrace (0 = no limit).">;
+ def fconstexpr_backtrace_limit : Separate<["-"], "fconstexpr-backtrace-limit">, MetaVarName<"<N>">,
+   HelpText<"Set the maximum number of entries to print in a constexpr evaluation backtrace (0 = no limit).">;
+ def fspell_checking_limit : Separate<["-"], "fspell-checking-limit">, MetaVarName<"<N>">,
+   HelpText<"Set the maximum number of times to perform spell checking on unrecognized identifiers (0 = no limit).">;
+ def fcaret_diagnostics_max_lines :
+   Separate<["-"], "fcaret-diagnostics-max-lines">, MetaVarName<"<N>">,
+   HelpText<"Set the maximum number of source lines to show in a caret diagnostic">;
+ def fmessage_length : Separate<["-"], "fmessage-length">, MetaVarName<"<N>">,
+   HelpText<"Format message diagnostics so that they fit within N columns or fewer, when possible.">;
+ def verify_EQ : CommaJoined<["-"], "verify=">,
+   MetaVarName<"<prefixes>">,
+   HelpText<"Verify diagnostic output using comment directives that start with"
+            " prefixes in the comma-separated sequence <prefixes>">;
+ def verify : Flag<["-"], "verify">,
+   HelpText<"Equivalent to -verify=expected">;
+ def verify_ignore_unexpected : Flag<["-"], "verify-ignore-unexpected">,
+   HelpText<"Ignore unexpected diagnostic messages">;
+ def verify_ignore_unexpected_EQ : CommaJoined<["-"], "verify-ignore-unexpected=">,
+   HelpText<"Ignore unexpected diagnostic messages">;
+ def Wno_rewrite_macros : Flag<["-"], "Wno-rewrite-macros">,
+   HelpText<"Silence ObjC rewriting warnings">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Frontend Options
+ //===----------------------------------------------------------------------===//
+ 
+ // This isn't normally used, it is just here so we can parse a
+ // CompilerInvocation out of a driver-derived argument vector.
+ def cc1 : Flag<["-"], "cc1">;
+ def cc1as : Flag<["-"], "cc1as">;
+ 
+ def ast_merge : Separate<["-"], "ast-merge">,
+   MetaVarName<"<ast file>">,
+   HelpText<"Merge the given AST file into the translation unit being compiled.">;
+ def aux_triple : Separate<["-"], "aux-triple">,
+   HelpText<"Auxiliary target triple.">;
+ def code_completion_at : Separate<["-"], "code-completion-at">,
+   MetaVarName<"<file>:<line>:<column>">,
+   HelpText<"Dump code-completion information at a location">;
+ def remap_file : Separate<["-"], "remap-file">,
+   MetaVarName<"<from>;<to>">,
+   HelpText<"Replace the contents of the <from> file with the contents of the <to> file">;
+ def code_completion_at_EQ : Joined<["-"], "code-completion-at=">,
+   Alias<code_completion_at>;
+ def code_completion_macros : Flag<["-"], "code-completion-macros">,
+   HelpText<"Include macros in code-completion results">;
+ def code_completion_patterns : Flag<["-"], "code-completion-patterns">,
+   HelpText<"Include code patterns in code-completion results">;
+ def no_code_completion_globals : Flag<["-"], "no-code-completion-globals">,
+   HelpText<"Do not include global declarations in code-completion results.">;
+ def no_code_completion_ns_level_decls : Flag<["-"], "no-code-completion-ns-level-decls">,
+   HelpText<"Do not include declarations inside namespaces (incl. global namespace) in the code-completion results.">;
+ def code_completion_brief_comments : Flag<["-"], "code-completion-brief-comments">,
+   HelpText<"Include brief documentation comments in code-completion results.">;
+ def disable_free : Flag<["-"], "disable-free">,
+   HelpText<"Disable freeing of memory on exit">;
+ def discard_value_names : Flag<["-"], "discard-value-names">,
+   HelpText<"Discard value names in LLVM IR">;
+ def load : Separate<["-"], "load">, MetaVarName<"<dsopath>">,
+   HelpText<"Load the named plugin (dynamic shared object)">;
+ def plugin : Separate<["-"], "plugin">, MetaVarName<"<name>">,
+   HelpText<"Use the named plugin action instead of the default action (use \"help\" to list available options)">;
+ def plugin_arg : JoinedAndSeparate<["-"], "plugin-arg-">,
+     MetaVarName<"<name> <arg>">,
+     HelpText<"Pass <arg> to plugin <name>">;
+ def add_plugin : Separate<["-"], "add-plugin">, MetaVarName<"<name>">,
+   HelpText<"Use the named plugin action in addition to the default action">;
+ def ast_dump_filter : Separate<["-"], "ast-dump-filter">,
+   MetaVarName<"<dump_filter>">,
+   HelpText<"Use with -ast-dump or -ast-print to dump/print only AST declaration"
+            " nodes having a certain substring in a qualified name. Use"
+            " -ast-list to list all filterable declaration node names.">;
+ def fno_modules_global_index : Flag<["-"], "fno-modules-global-index">,
+   HelpText<"Do not automatically generate or update the global module index">;
+ def fno_modules_error_recovery : Flag<["-"], "fno-modules-error-recovery">,
+   HelpText<"Do not automatically import modules for error recovery">;
+ def fmodule_map_file_home_is_cwd : Flag<["-"], "fmodule-map-file-home-is-cwd">,
+   HelpText<"Use the current working directory as the home directory of "
+            "module maps specified by -fmodule-map-file=<FILE>">;
+ def fmodule_feature : Separate<["-"], "fmodule-feature">,
+   MetaVarName<"<feature>">,
+   HelpText<"Enable <feature> in module map requires declarations">;
+ def fmodules_embed_file_EQ : Joined<["-"], "fmodules-embed-file=">,
+   MetaVarName<"<file>">,
+   HelpText<"Embed the contents of the specified file into the module file "
+            "being compiled.">;
+ def fmodules_embed_all_files : Joined<["-"], "fmodules-embed-all-files">,
+   HelpText<"Embed the contents of all files read by this compilation into "
+            "the produced module file.">;
+ def fmodules_local_submodule_visibility :
+   Flag<["-"], "fmodules-local-submodule-visibility">,
+   HelpText<"Enforce name visibility rules across submodules of the same "
+            "top-level module.">;
+ def fmodules_codegen :
+   Flag<["-"], "fmodules-codegen">,
+   HelpText<"Generate code for uses of this module that assumes an explicit "
+            "object file will be built for the module">;
+ def fmodules_debuginfo :
+   Flag<["-"], "fmodules-debuginfo">,
+   HelpText<"Generate debug info for types in an object file built from this "
+            "module and do not generate them elsewhere">;
+ def fmodule_format_EQ : Joined<["-"], "fmodule-format=">,
+   HelpText<"Select the container format for clang modules and PCH. "
+            "Supported options are 'raw' and 'obj'.">;
+ def ftest_module_file_extension_EQ :
+   Joined<["-"], "ftest-module-file-extension=">,
+   HelpText<"introduce a module file extension for testing purposes. "
+            "The argument is parsed as blockname:major:minor:hashed:user info">;
+ def fconcepts_ts : Flag<["-"], "fconcepts-ts">,
+   HelpText<"Enable C++ Extensions for Concepts.">;
++def templight_profile : Flag<["-"], "templight-profile">,
++  HelpText<"Add timestamps to the templight-dump output">;
+ 
+ let Group = Action_Group in {
+ 
+ def Eonly : Flag<["-"], "Eonly">,
+   HelpText<"Just run preprocessor, no output (for timings)">;
+ def dump_raw_tokens : Flag<["-"], "dump-raw-tokens">,
+   HelpText<"Lex file in raw mode and dump raw tokens">;
+ def analyze : Flag<["-"], "analyze">,
+   HelpText<"Run static analysis engine">;
+ def dump_tokens : Flag<["-"], "dump-tokens">,
+   HelpText<"Run preprocessor, dump internal rep of tokens">;
+ def init_only : Flag<["-"], "init-only">,
+   HelpText<"Only execute frontend initialization">;
+ def fixit : Flag<["-"], "fixit">,
+   HelpText<"Apply fix-it advice to the input source">;
+ def fixit_EQ : Joined<["-"], "fixit=">,
+   HelpText<"Apply fix-it advice creating a file with the given suffix">;
+ def print_preamble : Flag<["-"], "print-preamble">,
+   HelpText<"Print the \"preamble\" of a file, which is a candidate for implicit"
+            " precompiled headers.">;
+ def emit_html : Flag<["-"], "emit-html">,
+   HelpText<"Output input source as HTML">;
+ def ast_print : Flag<["-"], "ast-print">,
+   HelpText<"Build ASTs and then pretty-print them">;
+ def ast_list : Flag<["-"], "ast-list">,
+   HelpText<"Build ASTs and print the list of declaration node qualified names">;
+ def ast_dump : Flag<["-"], "ast-dump">,
+   HelpText<"Build ASTs and then debug dump them">;
+ def ast_dump_all : Flag<["-"], "ast-dump-all">,
+   HelpText<"Build ASTs and then debug dump them, forcing deserialization">;
+ def templight_dump : Flag<["-"], "templight-dump">,
+   HelpText<"Dump templight information to stdout">;
+ def ast_dump_lookups : Flag<["-"], "ast-dump-lookups">,
+   HelpText<"Build ASTs and then debug dump their name lookup tables">;
+ def ast_view : Flag<["-"], "ast-view">,
+   HelpText<"Build ASTs and view them with GraphViz">;
+ def print_decl_contexts : Flag<["-"], "print-decl-contexts">,
+   HelpText<"Print DeclContexts and their Decls">;
+ def emit_module : Flag<["-"], "emit-module">,
+   HelpText<"Generate pre-compiled module file from a module map">;
+ def emit_module_interface : Flag<["-"], "emit-module-interface">,
+   HelpText<"Generate pre-compiled module file from a C++ module interface">;
+ def emit_pth : Flag<["-"], "emit-pth">,
+   HelpText<"Generate pre-tokenized header file">;
+ def emit_pch : Flag<["-"], "emit-pch">,
+   HelpText<"Generate pre-compiled header file">;
+ def emit_llvm_bc : Flag<["-"], "emit-llvm-bc">,
+   HelpText<"Build ASTs then convert to LLVM, emit .bc file">;
+ def emit_llvm_only : Flag<["-"], "emit-llvm-only">,
+   HelpText<"Build ASTs and convert to LLVM, discarding output">;
+ def emit_codegen_only : Flag<["-"], "emit-codegen-only">,
+   HelpText<"Generate machine code, but discard output">;
+ def emit_obj : Flag<["-"], "emit-obj">,
+   HelpText<"Emit native object files">;
+ def rewrite_test : Flag<["-"], "rewrite-test">,
+   HelpText<"Rewriter playground">;
+ def rewrite_macros : Flag<["-"], "rewrite-macros">,
+   HelpText<"Expand macros without full preprocessing">;
+ def migrate : Flag<["-"], "migrate">,
+   HelpText<"Migrate source code">;
+ }
+ 
+ def emit_llvm_uselists : Flag<["-"], "emit-llvm-uselists">,
+   HelpText<"Preserve order of LLVM use-lists when serializing">;
+ def no_emit_llvm_uselists : Flag<["-"], "no-emit-llvm-uselists">,
+   HelpText<"Don't preserve order of LLVM use-lists when serializing">;
+ 
+ def mt_migrate_directory : Separate<["-"], "mt-migrate-directory">,
+   HelpText<"Directory for temporary files produced during ARC or ObjC migration">;
+ def arcmt_check : Flag<["-"], "arcmt-check">,
+   HelpText<"Check for ARC migration issues that need manual handling">;
+ def arcmt_modify : Flag<["-"], "arcmt-modify">,
+   HelpText<"Apply modifications to files to conform to ARC">;
+ def arcmt_migrate : Flag<["-"], "arcmt-migrate">,
+   HelpText<"Apply modifications and produces temporary files that conform to ARC">;
+ 
+ def opt_record_file : Separate<["-"], "opt-record-file">,
+   HelpText<"File name to use for YAML optimization record output">;
+ 
+ def print_stats : Flag<["-"], "print-stats">,
+   HelpText<"Print performance metrics and statistics">;
+ def stats_file : Joined<["-"], "stats-file=">,
+   HelpText<"Filename to write statistics to">;
+ def fdump_record_layouts : Flag<["-"], "fdump-record-layouts">,
+   HelpText<"Dump record layout information">;
+ def fdump_record_layouts_simple : Flag<["-"], "fdump-record-layouts-simple">,
+   HelpText<"Dump record layout information in a simple form used for testing">;
+ def fix_what_you_can : Flag<["-"], "fix-what-you-can">,
+   HelpText<"Apply fix-it advice even in the presence of unfixable errors">;
+ def fix_only_warnings : Flag<["-"], "fix-only-warnings">,
+   HelpText<"Apply fix-it advice only for warnings, not errors">;
+ def fixit_recompile : Flag<["-"], "fixit-recompile">,
+   HelpText<"Apply fix-it changes and recompile">;
+ def fixit_to_temp : Flag<["-"], "fixit-to-temporary">,
+   HelpText<"Apply fix-it changes to temporary files">;
+ 
+ def foverride_record_layout_EQ : Joined<["-"], "foverride-record-layout=">,
+   HelpText<"Override record layouts with those in the given file">;
+ def find_pch_source_EQ : Joined<["-"], "find-pch-source=">,
+   HelpText<"When building a pch, try to find the input file in include "
+            "directories, as if it had been included by the argument passed "
+            "to this flag.">;
+ def fno_pch_timestamp : Flag<["-"], "fno-pch-timestamp">,
+   HelpText<"Disable inclusion of timestamp in precompiled headers">;
+   
+ def aligned_alloc_unavailable : Flag<["-"], "faligned-alloc-unavailable">,
+   HelpText<"Aligned allocation/deallocation functions are unavailable">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Language Options
+ //===----------------------------------------------------------------------===//
+ 
+ let Flags = [CC1Option, CC1AsOption, NoDriverOption] in {
+ 
+ def version : Flag<["-"], "version">,
+   HelpText<"Print the compiler version">;
+ def main_file_name : Separate<["-"], "main-file-name">,
+   HelpText<"Main file name to use for debug info">;
+ 
+ }
+ 
+ def fblocks_runtime_optional : Flag<["-"], "fblocks-runtime-optional">,
+   HelpText<"Weakly link in the blocks runtime">;
+ def fexternc_nounwind : Flag<["-"], "fexternc-nounwind">,
+   HelpText<"Assume all functions with C linkage do not unwind">;
+ def enable_split_dwarf : Flag<["-"], "enable-split-dwarf">,
+   HelpText<"Use split dwarf/Fission">;
+ def split_dwarf_file : Separate<["-"], "split-dwarf-file">,
+   HelpText<"File name to use for split dwarf debug info output">;
+ def fno_wchar : Flag<["-"], "fno-wchar">,
+   HelpText<"Disable C++ builtin type wchar_t">;
+ def fconstant_string_class : Separate<["-"], "fconstant-string-class">,
+   MetaVarName<"<class name>">,
+   HelpText<"Specify the class to use for constant Objective-C string objects.">;
+ def fobjc_arc_cxxlib_EQ : Joined<["-"], "fobjc-arc-cxxlib=">,
+   HelpText<"Objective-C++ Automatic Reference Counting standard library kind">, Values<"libc++,libstdc++,none">;
+ def fobjc_runtime_has_weak : Flag<["-"], "fobjc-runtime-has-weak">,
+   HelpText<"The target Objective-C runtime supports ARC weak operations">;
+ def fobjc_dispatch_method_EQ : Joined<["-"], "fobjc-dispatch-method=">,
+   HelpText<"Objective-C dispatch method to use">, Values<"legacy,non-legacy,mixed">;
+ def disable_objc_default_synthesize_properties : Flag<["-"], "disable-objc-default-synthesize-properties">,
+   HelpText<"disable the default synthesis of Objective-C properties">;
+ def fencode_extended_block_signature : Flag<["-"], "fencode-extended-block-signature">,
+   HelpText<"enable extended encoding of block type signature">;
+ def pic_level : Separate<["-"], "pic-level">,
+   HelpText<"Value for __PIC__">;
+ def pic_is_pie : Flag<["-"], "pic-is-pie">,
+   HelpText<"File is for a position independent executable">;
+ def fno_validate_pch : Flag<["-"], "fno-validate-pch">,
+   HelpText<"Disable validation of precompiled headers">;
+ def fallow_pch_with_errors : Flag<["-"], "fallow-pch-with-compiler-errors">,
+   HelpText<"Accept a PCH file that was created with compiler errors">;
+ def dump_deserialized_pch_decls : Flag<["-"], "dump-deserialized-decls">,
+   HelpText<"Dump declarations that are deserialized from PCH, for testing">;
+ def error_on_deserialized_pch_decl : Separate<["-"], "error-on-deserialized-decl">,
+   HelpText<"Emit error if a specific declaration is deserialized from PCH, for testing">;
+ def error_on_deserialized_pch_decl_EQ : Joined<["-"], "error-on-deserialized-decl=">,
+   Alias<error_on_deserialized_pch_decl>;
+ def static_define : Flag<["-"], "static-define">,
+   HelpText<"Should __STATIC__ be defined">;
+ def stack_protector : Separate<["-"], "stack-protector">,
+   HelpText<"Enable stack protectors">;
+ def stack_protector_buffer_size : Separate<["-"], "stack-protector-buffer-size">,
+   HelpText<"Lower bound for a buffer to be considered for stack protection">;
+ def fvisibility : Separate<["-"], "fvisibility">,
+   HelpText<"Default type and symbol visibility">;
+ def ftype_visibility : Separate<["-"], "ftype-visibility">,
+   HelpText<"Default type visibility">;
+ def ftemplate_depth : Separate<["-"], "ftemplate-depth">,
+   HelpText<"Maximum depth of recursive template instantiation">;
+ def foperator_arrow_depth : Separate<["-"], "foperator-arrow-depth">,
+   HelpText<"Maximum number of 'operator->'s to call for a member access">;
+ def fconstexpr_depth : Separate<["-"], "fconstexpr-depth">,
+   HelpText<"Maximum depth of recursive constexpr function calls">;
+ def fconstexpr_steps : Separate<["-"], "fconstexpr-steps">,
+   HelpText<"Maximum number of steps in constexpr function evaluation">;
+ def fbracket_depth : Separate<["-"], "fbracket-depth">,
+   HelpText<"Maximum nesting level for parentheses, brackets, and braces">;
+ def fconst_strings : Flag<["-"], "fconst-strings">,
+   HelpText<"Use a const qualified type for string literals in C and ObjC">;
+ def fno_const_strings : Flag<["-"], "fno-const-strings">,
+   HelpText<"Don't use a const qualified type for string literals in C and ObjC">;
+ def fno_bitfield_type_align : Flag<["-"], "fno-bitfield-type-align">,
+   HelpText<"Ignore bit-field types when aligning structures">;
+ def ffake_address_space_map : Flag<["-"], "ffake-address-space-map">,
+   HelpText<"Use a fake address space map; OpenCL testing purposes only">;
+ def faddress_space_map_mangling_EQ : Joined<["-"], "faddress-space-map-mangling=">, MetaVarName<"<yes|no|target>">,
+   HelpText<"Set the mode for address space map based mangling; OpenCL testing purposes only">;
+ def funknown_anytype : Flag<["-"], "funknown-anytype">,
+   HelpText<"Enable parser support for the __unknown_anytype type; for testing purposes only">;
+ def fdebugger_support : Flag<["-"], "fdebugger-support">,
+   HelpText<"Enable special debugger support behavior">;
+ def fdebugger_cast_result_to_id : Flag<["-"], "fdebugger-cast-result-to-id">,
+   HelpText<"Enable casting unknown expression results to id">;
+ def fdebugger_objc_literal : Flag<["-"], "fdebugger-objc-literal">,
+   HelpText<"Enable special debugger support for Objective-C subscripting and literals">;
+ def fdeprecated_macro : Flag<["-"], "fdeprecated-macro">,
+   HelpText<"Defines the __DEPRECATED macro">;
+ def fno_deprecated_macro : Flag<["-"], "fno-deprecated-macro">,
+   HelpText<"Undefines the __DEPRECATED macro">;
+ def fobjc_subscripting_legacy_runtime : Flag<["-"], "fobjc-subscripting-legacy-runtime">,
+   HelpText<"Allow Objective-C array and dictionary subscripting in legacy runtime">;
+ def vtordisp_mode_EQ : Joined<["-"], "vtordisp-mode=">,
+   HelpText<"Control vtordisp placement on win32 targets">;
+ def fno_rtti_data : Flag<["-"], "fno-rtti-data">,
+   HelpText<"Control emission of RTTI data">;
+ def fnative_half_type: Flag<["-"], "fnative-half-type">,
+   HelpText<"Use the native half type for __fp16 instead of promoting to float">;
+ def fnative_half_arguments_and_returns : Flag<["-"], "fnative-half-arguments-and-returns">,
+   HelpText<"Use the native __fp16 type for arguments and returns (and skip ABI-specific lowering)">;
+ def fallow_half_arguments_and_returns : Flag<["-"], "fallow-half-arguments-and-returns">,
+   HelpText<"Allow function arguments and returns of type half">;
+ def fdefault_calling_conv_EQ : Joined<["-"], "fdefault-calling-conv=">,
+   HelpText<"Set default calling convention">, Values<"cdecl,fastcall,stdcall,vectorcall,regcall">;
+ def finclude_default_header : Flag<["-"], "finclude-default-header">,
+   HelpText<"Include the default header file for OpenCL">;
+ def fpreserve_vec3_type : Flag<["-"], "fpreserve-vec3-type">,
+   HelpText<"Preserve 3-component vector type">;
+ def fwchar_type_EQ : Joined<["-"], "fwchar-type=">,
+   HelpText<"Select underlying type for wchar_t">, Values<"char,short,int">;
+ def fsigned_wchar : Flag<["-"], "fsigned-wchar">,
+   HelpText<"Use a signed type for wchar_t">;
+ def fno_signed_wchar : Flag<["-"], "fno-signed-wchar">,
+   HelpText<"Use an unsigned type for wchar_t">;
+ 
+ // FIXME: Remove these entirely once functionality/tests have been excised.
+ def fobjc_gc_only : Flag<["-"], "fobjc-gc-only">, Group<f_Group>,
+   HelpText<"Use GC exclusively for Objective-C related memory management">;
+ def fobjc_gc : Flag<["-"], "fobjc-gc">, Group<f_Group>,
+   HelpText<"Enable Objective-C garbage collection">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Header Search Options
+ //===----------------------------------------------------------------------===//
+ 
+ def nostdsysteminc : Flag<["-"], "nostdsysteminc">,
+   HelpText<"Disable standard system #include directories">;
+ def fdisable_module_hash : Flag<["-"], "fdisable-module-hash">,
+   HelpText<"Disable the module hash">;
+ def fmodules_hash_content : Flag<["-"], "fmodules-hash-content">,
+   HelpText<"Enable hashing the content of a module file">;
+ def c_isystem : JoinedOrSeparate<["-"], "c-isystem">, MetaVarName<"<directory>">,
+   HelpText<"Add directory to the C SYSTEM include search path">;
+ def objc_isystem : JoinedOrSeparate<["-"], "objc-isystem">,
+   MetaVarName<"<directory>">,
+   HelpText<"Add directory to the ObjC SYSTEM include search path">;
+ def objcxx_isystem : JoinedOrSeparate<["-"], "objcxx-isystem">,
+   MetaVarName<"<directory>">,
+   HelpText<"Add directory to the ObjC++ SYSTEM include search path">;
+ def internal_isystem : JoinedOrSeparate<["-"], "internal-isystem">,
+   MetaVarName<"<directory>">,
+   HelpText<"Add directory to the internal system include search path; these "
+            "are assumed to not be user-provided and are used to model system "
+            "and standard headers' paths.">;
+ def internal_externc_isystem : JoinedOrSeparate<["-"], "internal-externc-isystem">,
+   MetaVarName<"<directory>">,
+   HelpText<"Add directory to the internal system include search path with "
+            "implicit extern \"C\" semantics; these are assumed to not be "
+            "user-provided and are used to model system and standard headers' "
+            "paths.">;
+ 
+ //===----------------------------------------------------------------------===//
+ // Preprocessor Options
+ //===----------------------------------------------------------------------===//
+ 
+ def include_pth : Separate<["-"], "include-pth">, MetaVarName<"<file>">,
+   HelpText<"Include file before parsing">;
+ def chain_include : Separate<["-"], "chain-include">, MetaVarName<"<file>">,
+   HelpText<"Include and chain a header file after turning it into PCH">;
+ def preamble_bytes_EQ : Joined<["-"], "preamble-bytes=">,
+   HelpText<"Assume that the precompiled header is a precompiled preamble "
+            "covering the first N bytes of the main file">;
+ def token_cache : Separate<["-"], "token-cache">, MetaVarName<"<path>">,
+   HelpText<"Use specified token cache file">;
+ def detailed_preprocessing_record : Flag<["-"], "detailed-preprocessing-record">,
+   HelpText<"include a detailed record of preprocessing actions">;
+ 
+ //===----------------------------------------------------------------------===//
+ // OpenCL Options
+ //===----------------------------------------------------------------------===//
+ 
+ def cl_ext_EQ : CommaJoined<["-"], "cl-ext=">,
+   HelpText<"OpenCL only. Enable or disable OpenCL extensions. The argument is a comma-separated sequence of one or more extension names, each prefixed by '+' or '-'.">;
+ 
+ //===----------------------------------------------------------------------===//
+ // CUDA Options
+ //===----------------------------------------------------------------------===//
+ 
+ def fcuda_is_device : Flag<["-"], "fcuda-is-device">,
+   HelpText<"Generate code for CUDA device">;
+ def fcuda_include_gpubinary : Separate<["-"], "fcuda-include-gpubinary">,
+   HelpText<"Incorporate CUDA device-side binary into host object file.">;
+ def fcuda_allow_variadic_functions : Flag<["-"], "fcuda-allow-variadic-functions">,
+   HelpText<"Allow variadic functions in CUDA device code.">;
+ def fno_cuda_host_device_constexpr : Flag<["-"], "fno-cuda-host-device-constexpr">,
+   HelpText<"Don't treat unattributed constexpr functions as __host__ __device__.">;
+ 
+ //===----------------------------------------------------------------------===//
+ // OpenMP Options
+ //===----------------------------------------------------------------------===//
+ 
+ def fopenmp_is_device : Flag<["-"], "fopenmp-is-device">,
+   HelpText<"Generate code only for an OpenMP target device.">;
+ def fopenmp_host_ir_file_path : Separate<["-"], "fopenmp-host-ir-file-path">,
+   HelpText<"Path to the IR file produced by the frontend for the host.">;
+   
+ } // let Flags = [CC1Option]
+ 
+ 
+ //===----------------------------------------------------------------------===//
+ // cc1as-only Options
+ //===----------------------------------------------------------------------===//
+ 
+ let Flags = [CC1AsOption, NoDriverOption] in {
+ 
+ // Language Options
+ def n : Flag<["-"], "n">,
+   HelpText<"Don't automatically start assembly file with a text section">;
+ 
+ // Frontend Options
+ def filetype : Separate<["-"], "filetype">,
+     HelpText<"Specify the output file type ('asm', 'null', or 'obj')">;
+ 
+ // Transliterate Options
+ def output_asm_variant : Separate<["-"], "output-asm-variant">,
+     HelpText<"Select the asm variant index to use for output">;
+ def show_encoding : Flag<["-"], "show-encoding">,
+     HelpText<"Show instruction encoding information in transliterate mode">;
+ def show_inst : Flag<["-"], "show-inst">,
+     HelpText<"Show internal instruction representation in transliterate mode">;
+ 
+ // Assemble Options
+ def dwarf_debug_producer : Separate<["-"], "dwarf-debug-producer">,
+   HelpText<"The string to embed in the Dwarf debug AT_producer record.">;
+ 
+ def defsym : Separate<["-"], "defsym">,
+   HelpText<"Define a value for a symbol">;
+ } // let Flags = [CC1AsOption]
+diff --git a/include/clang/Frontend/FrontendOptions.h b/include/clang/Frontend/FrontendOptions.h
+index c609500..af3a22b 100644
+--- a/include/clang/Frontend/FrontendOptions.h
++++ b/include/clang/Frontend/FrontendOptions.h
+@@ -1,354 +1,357 @@
+ //===--- FrontendOptions.h --------------------------------------*- C++ -*-===//
+ //
+ //                     The LLVM Compiler Infrastructure
+ //
+ // This file is distributed under the University of Illinois Open Source
+ // License. See LICENSE.TXT for details.
+ //
+ //===----------------------------------------------------------------------===//
+ 
+ #ifndef LLVM_CLANG_FRONTEND_FRONTENDOPTIONS_H
+ #define LLVM_CLANG_FRONTEND_FRONTENDOPTIONS_H
+ 
+ #include "clang/Frontend/CommandLineSourceLoc.h"
+ #include "clang/Serialization/ModuleFileExtension.h"
+ #include "clang/Sema/CodeCompleteOptions.h"
+ #include "llvm/ADT/StringRef.h"
+ #include <string>
+ #include <vector>
+ #include <unordered_map>
+ 
+ namespace llvm {
+ class MemoryBuffer;
+ }
+ 
+ namespace clang {
+ class FileEntry;
+ 
+ namespace frontend {
+   enum ActionKind {
+     ASTDeclList,            ///< Parse ASTs and list Decl nodes.
+     ASTDump,                ///< Parse ASTs and dump them.
+     ASTPrint,               ///< Parse ASTs and print them.
+     ASTView,                ///< Parse ASTs and view them in Graphviz.
+     DumpRawTokens,          ///< Dump out raw tokens.
+     DumpTokens,             ///< Dump out preprocessed tokens.
+     EmitAssembly,           ///< Emit a .s file.
+     EmitBC,                 ///< Emit a .bc file.
+     EmitHTML,               ///< Translate input source into HTML.
+     EmitLLVM,               ///< Emit a .ll file.
+     EmitLLVMOnly,           ///< Generate LLVM IR, but do not emit anything.
+     EmitCodeGenOnly,        ///< Generate machine code, but don't emit anything.
+     EmitObj,                ///< Emit a .o file.
+     FixIt,                  ///< Parse and apply any fixits to the source.
+     GenerateModule,         ///< Generate pre-compiled module from a module map.
+     GenerateModuleInterface,///< Generate pre-compiled module from a C++ module
+                             ///< interface file.
+     GeneratePCH,            ///< Generate pre-compiled header.
+     GeneratePTH,            ///< Generate pre-tokenized header.
+     InitOnly,               ///< Only execute frontend initialization.
+     ModuleFileInfo,         ///< Dump information about a module file.
+     VerifyPCH,              ///< Load and verify that a PCH file is usable.
+     ParseSyntaxOnly,        ///< Parse and perform semantic analysis.
+     PluginAction,           ///< Run a plugin action, \see ActionName.
+     PrintDeclContext,       ///< Print DeclContext and their Decls.
+-    PrintPreamble,          ///< Print the "preamble" of the input file
++    PrintPreamble,          ///< Print the "preamble" of the input file.
+     PrintPreprocessedInput, ///< -E mode.
+     RewriteMacros,          ///< Expand macros but not \#includes.
+     RewriteObjC,            ///< ObjC->C Rewriter.
+-    RewriteTest,            ///< Rewriter playground
++    RewriteTest,            ///< Rewriter playground.
+     RunAnalysis,            ///< Run one or more source code analyses.
+-    TemplightDump,          ///< Dump template instantiations
++    TemplightDump,          ///< Dump template instantiations.
+     MigrateSource,          ///< Run migrator.
+     RunPreprocessorOnly     ///< Just lex, no output.
+   };
+ }
+ 
+ /// The kind of a file that we've been handed as an input.
+ class InputKind {
+ private:
+   unsigned Lang : 4;
+   unsigned Fmt : 3;
+   unsigned Preprocessed : 1;
+ 
+ public:
+   /// The language for the input, used to select and validate the language
+   /// standard and possible actions.
+   enum Language {
+     Unknown,
+ 
+     /// Assembly: we accept this only so that we can preprocess it.
+     Asm,
+ 
+     /// LLVM IR: we accept this so that we can run the optimizer on it,
+     /// and compile it to assembly or object code.
+     LLVM_IR,
+ 
+     ///@{ Languages that the frontend can parse and compile.
+     C,
+     CXX,
+     ObjC,
+     ObjCXX,
+     OpenCL,
+     CUDA,
+     RenderScript,
+     ///@}
+   };
+ 
+   /// The input file format.
+   enum Format {
+     Source,
+     ModuleMap,
+     Precompiled
+   };
+ 
+   constexpr InputKind(Language L = Unknown, Format F = Source,
+                       bool PP = false)
+       : Lang(L), Fmt(F), Preprocessed(PP) {}
+ 
+   Language getLanguage() const { return static_cast<Language>(Lang); }
+   Format getFormat() const { return static_cast<Format>(Fmt); }
+   bool isPreprocessed() const { return Preprocessed; }
+ 
+   /// Is the input kind fully-unknown?
+   bool isUnknown() const { return Lang == Unknown && Fmt == Source; }
+ 
+   /// Is the language of the input some dialect of Objective-C?
+   bool isObjectiveC() const { return Lang == ObjC || Lang == ObjCXX; }
+ 
+   InputKind getPreprocessed() const {
+     return InputKind(getLanguage(), getFormat(), true);
+   }
+   InputKind withFormat(Format F) const {
+     return InputKind(getLanguage(), F, isPreprocessed());
+   }
+ };
+ 
+ /// \brief An input file for the front end.
+ class FrontendInputFile {
+   /// \brief The file name, or "-" to read from standard input.
+   std::string File;
+ 
+   /// The input, if it comes from a buffer rather than a file. This object
+   /// does not own the buffer, and the caller is responsible for ensuring
+   /// that it outlives any users.
+   llvm::MemoryBuffer *Buffer = nullptr;
+ 
+   /// \brief The kind of input, e.g., C source, AST file, LLVM IR.
+   InputKind Kind;
+ 
+   /// \brief Whether we're dealing with a 'system' input (vs. a 'user' input).
+   bool IsSystem = false;
+ 
+ public:
+   FrontendInputFile() { }
+   FrontendInputFile(StringRef File, InputKind Kind, bool IsSystem = false)
+     : File(File.str()), Kind(Kind), IsSystem(IsSystem) { }
+   FrontendInputFile(llvm::MemoryBuffer *Buffer, InputKind Kind,
+                     bool IsSystem = false)
+     : Buffer(Buffer), Kind(Kind), IsSystem(IsSystem) { }
+ 
+   InputKind getKind() const { return Kind; }
+   bool isSystem() const { return IsSystem; }
+ 
+   bool isEmpty() const { return File.empty() && Buffer == nullptr; }
+   bool isFile() const { return !isBuffer(); }
+   bool isBuffer() const { return Buffer != nullptr; }
+   bool isPreprocessed() const { return Kind.isPreprocessed(); }
+ 
+   StringRef getFile() const {
+     assert(isFile());
+     return File;
+   }
+   llvm::MemoryBuffer *getBuffer() const {
+     assert(isBuffer());
+     return Buffer;
+   }
+ };
+ 
+ /// FrontendOptions - Options for controlling the behavior of the frontend.
+ class FrontendOptions {
+ public:
+   unsigned DisableFree : 1;                ///< Disable memory freeing on exit.
+   unsigned RelocatablePCH : 1;             ///< When generating PCH files,
+                                            /// instruct the AST writer to create
+                                            /// relocatable PCH files.
+   unsigned ShowHelp : 1;                   ///< Show the -help text.
+   unsigned ShowStats : 1;                  ///< Show frontend performance
+                                            /// metrics and statistics.
+   unsigned ShowTimers : 1;                 ///< Show timers for individual
+                                            /// actions.
+   unsigned ShowVersion : 1;                ///< Show the -version text.
+   unsigned FixWhatYouCan : 1;              ///< Apply fixes even if there are
+                                            /// unfixable errors.
+   unsigned FixOnlyWarnings : 1;            ///< Apply fixes only for warnings.
+   unsigned FixAndRecompile : 1;            ///< Apply fixes and recompile.
+   unsigned FixToTemporaries : 1;           ///< Apply fixes to temporary files.
+   unsigned ARCMTMigrateEmitARCErrors : 1;  /// Emit ARC errors even if the
+                                            /// migrator can fix them
+   unsigned SkipFunctionBodies : 1;         ///< Skip over function bodies to
+                                            /// speed up parsing in cases you do
+                                            /// not need them (e.g. with code
+                                            /// completion).
+   unsigned UseGlobalModuleIndex : 1;       ///< Whether we can use the
+                                            ///< global module index if available.
+   unsigned GenerateGlobalModuleIndex : 1;  ///< Whether we can generate the
+                                            ///< global module index if needed.
+   unsigned ASTDumpDecls : 1;               ///< Whether we include declaration
+                                            ///< dumps in AST dumps.
+   unsigned ASTDumpAll : 1;                 ///< Whether we deserialize all decls
+                                            ///< when forming AST dumps.
+   unsigned ASTDumpLookups : 1;             ///< Whether we include lookup table
+                                            ///< dumps in AST dumps.
+   unsigned BuildingImplicitModule : 1;     ///< Whether we are performing an
+                                            ///< implicit module build.
+   unsigned ModulesEmbedAllFiles : 1;       ///< Whether we should embed all used
+                                            ///< files into the PCM file.
+   unsigned IncludeTimestamps : 1;          ///< Whether timestamps should be
+                                            ///< written to the produced PCH file.
++  unsigned TemplightProfile : 1;           ///< Whether to add additional
++                                           ///< information to Templight dumps.
++
+ 
+   CodeCompleteOptions CodeCompleteOpts;
+ 
+   enum {
+     ARCMT_None,
+     ARCMT_Check,
+     ARCMT_Modify,
+     ARCMT_Migrate
+   } ARCMTAction;
+ 
+   enum {
+     ObjCMT_None = 0,
+     /// \brief Enable migration to modern ObjC literals.
+     ObjCMT_Literals = 0x1,
+     /// \brief Enable migration to modern ObjC subscripting.
+     ObjCMT_Subscripting = 0x2,
+     /// \brief Enable migration to modern ObjC readonly property.
+     ObjCMT_ReadonlyProperty = 0x4,
+     /// \brief Enable migration to modern ObjC readwrite property.
+     ObjCMT_ReadwriteProperty = 0x8,
+     /// \brief Enable migration to modern ObjC property.
+     ObjCMT_Property = (ObjCMT_ReadonlyProperty | ObjCMT_ReadwriteProperty),
+     /// \brief Enable annotation of ObjCMethods of all kinds.
+     ObjCMT_Annotation = 0x10,
+     /// \brief Enable migration of ObjC methods to 'instancetype'.
+     ObjCMT_Instancetype = 0x20,
+     /// \brief Enable migration to NS_ENUM/NS_OPTIONS macros.
+     ObjCMT_NsMacros = 0x40,
+     /// \brief Enable migration to add conforming protocols.
+     ObjCMT_ProtocolConformance = 0x80,
+     /// \brief prefer 'atomic' property over 'nonatomic'.
+     ObjCMT_AtomicProperty = 0x100,
+     /// \brief annotate property with NS_RETURNS_INNER_POINTER
+     ObjCMT_ReturnsInnerPointerProperty = 0x200,
+     /// \brief use NS_NONATOMIC_IOSONLY for property 'atomic' attribute
+     ObjCMT_NsAtomicIOSOnlyProperty = 0x400,
+     /// \brief Enable inferring NS_DESIGNATED_INITIALIZER for ObjC methods.
+     ObjCMT_DesignatedInitializer = 0x800,
+     /// \brief Enable converting setter/getter expressions to property-dot syntx.
+     ObjCMT_PropertyDotSyntax = 0x1000,
+     ObjCMT_MigrateDecls = (ObjCMT_ReadonlyProperty | ObjCMT_ReadwriteProperty |
+                            ObjCMT_Annotation | ObjCMT_Instancetype |
+                            ObjCMT_NsMacros | ObjCMT_ProtocolConformance |
+                            ObjCMT_NsAtomicIOSOnlyProperty |
+                            ObjCMT_DesignatedInitializer),
+     ObjCMT_MigrateAll = (ObjCMT_Literals | ObjCMT_Subscripting |
+                          ObjCMT_MigrateDecls | ObjCMT_PropertyDotSyntax)
+   };
+   unsigned ObjCMTAction;
+   std::string ObjCMTWhiteListPath;
+ 
+   std::string MTMigrateDir;
+   std::string ARCMTMigrateReportOut;
+ 
+   /// The input files and their types.
+   std::vector<FrontendInputFile> Inputs;
+ 
+   /// When the input is a module map, the original module map file from which
+   /// that map was inferred, if any (for umbrella modules).
+   std::string OriginalModuleMap;
+ 
+   /// The output file, if any.
+   std::string OutputFile;
+ 
+   /// If given, the new suffix for fix-it rewritten files.
+   std::string FixItSuffix;
+ 
+   /// If given, filter dumped AST Decl nodes by this substring.
+   std::string ASTDumpFilter;
+ 
+   /// If given, enable code completion at the provided location.
+   ParsedSourceLocation CodeCompletionAt;
+ 
+   /// The frontend action to perform.
+   frontend::ActionKind ProgramAction;
+ 
+   /// The name of the action to run when using a plugin action.
+   std::string ActionName;
+ 
+   /// Args to pass to the plugins
+   std::unordered_map<std::string,std::vector<std::string>> PluginArgs;
+ 
+   /// The list of plugin actions to run in addition to the normal action.
+   std::vector<std::string> AddPluginActions;
+ 
+   /// The list of plugins to load.
+   std::vector<std::string> Plugins;
+ 
+   /// The list of module file extensions.
+   std::vector<std::shared_ptr<ModuleFileExtension>> ModuleFileExtensions;
+ 
+   /// \brief The list of module map files to load before processing the input.
+   std::vector<std::string> ModuleMapFiles;
+ 
+   /// \brief The list of additional prebuilt module files to load before
+   /// processing the input.
+   std::vector<std::string> ModuleFiles;
+ 
+   /// \brief The list of files to embed into the compiled module file.
+   std::vector<std::string> ModulesEmbedFiles;
+ 
+   /// \brief The list of AST files to merge.
+   std::vector<std::string> ASTMergeFiles;
+ 
+   /// \brief A list of arguments to forward to LLVM's option processing; this
+   /// should only be used for debugging and experimental features.
+   std::vector<std::string> LLVMArgs;
+ 
+   /// \brief File name of the file that will provide record layouts
+   /// (in the format produced by -fdump-record-layouts).
+   std::string OverrideRecordLayoutsFile;
+ 
+   /// \brief Auxiliary triple for CUDA compilation.
+   std::string AuxTriple;
+ 
+   /// \brief If non-empty, search the pch input file as if it was a header
+   /// included by this file.
+   std::string FindPchSource;
+ 
+   /// Filename to write statistics to.
+   std::string StatsFile;
+ 
+ public:
+   FrontendOptions() :
+     DisableFree(false), RelocatablePCH(false), ShowHelp(false),
+     ShowStats(false), ShowTimers(false), ShowVersion(false),
+     FixWhatYouCan(false), FixOnlyWarnings(false), FixAndRecompile(false),
+     FixToTemporaries(false), ARCMTMigrateEmitARCErrors(false),
+     SkipFunctionBodies(false), UseGlobalModuleIndex(true),
+     GenerateGlobalModuleIndex(true), ASTDumpDecls(false), ASTDumpLookups(false),
+     BuildingImplicitModule(false), ModulesEmbedAllFiles(false),
+-    IncludeTimestamps(true), ARCMTAction(ARCMT_None),
++    IncludeTimestamps(true), TemplightProfile(false), ARCMTAction(ARCMT_None),
+     ObjCMTAction(ObjCMT_None), ProgramAction(frontend::ParseSyntaxOnly)
+   {}
+ 
+   /// getInputKindForExtension - Return the appropriate input kind for a file
+   /// extension. For example, "c" would return InputKind::C.
+   ///
+   /// \return The input kind for the extension, or InputKind::Unknown if the
+   /// extension is not recognized.
+   static InputKind getInputKindForExtension(StringRef Extension);
+ };
+ 
+ }  // end namespace clang
+ 
+ #endif
+diff --git a/lib/Frontend/CompilerInvocation.cpp b/lib/Frontend/CompilerInvocation.cpp
+index 3bdc116..571928a 100644
+--- a/lib/Frontend/CompilerInvocation.cpp
++++ b/lib/Frontend/CompilerInvocation.cpp
+@@ -1,3054 +1,3055 @@
+ //===--- CompilerInvocation.cpp -------------------------------------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+ //
+ // This file is distributed under the University of Illinois Open Source
+ // License. See LICENSE.TXT for details.
+ //
+ //===----------------------------------------------------------------------===//
+ 
+ #include "clang/Frontend/CompilerInvocation.h"
+ #include "TestModuleFileExtension.h"
+ #include "clang/Basic/Builtins.h"
+ #include "clang/Basic/FileManager.h"
+ #include "clang/Basic/Version.h"
+ #include "clang/Config/config.h"
+ #include "clang/Driver/DriverDiagnostic.h"
+ #include "clang/Driver/Options.h"
+ #include "clang/Driver/Util.h"
+ #include "clang/Frontend/FrontendDiagnostic.h"
+ #include "clang/Frontend/LangStandard.h"
+ #include "clang/Frontend/Utils.h"
+ #include "clang/Lex/HeaderSearchOptions.h"
+ #include "clang/Lex/PreprocessorOptions.h"
+ #include "clang/Serialization/ASTReader.h"
+ #include "clang/Serialization/ModuleFileExtension.h"
+ #include "llvm/ADT/Hashing.h"
+ #include "llvm/ADT/STLExtras.h"
+ #include "llvm/ADT/SmallVector.h"
+ #include "llvm/ADT/StringExtras.h"
+ #include "llvm/ADT/StringSwitch.h"
+ #include "llvm/ADT/Triple.h"
+ #include "llvm/Linker/Linker.h"
+ #include "llvm/Option/Arg.h"
+ #include "llvm/Option/ArgList.h"
+ #include "llvm/Option/OptTable.h"
+ #include "llvm/Option/Option.h"
+ #include "llvm/ProfileData/InstrProfReader.h"
+ #include "llvm/Support/CodeGen.h"
+ #include "llvm/Support/ErrorHandling.h"
+ #include "llvm/Support/FileSystem.h"
+ #include "llvm/Support/Host.h"
+ #include "llvm/Support/Path.h"
+ #include "llvm/Support/Process.h"
+ #include "llvm/Target/TargetOptions.h"
+ #include "llvm/Support/ScopedPrinter.h"
+ #include <atomic>
+ #include <memory>
+ #include <sys/stat.h>
+ #include <system_error>
+ using namespace clang;
+ 
+ //===----------------------------------------------------------------------===//
+ // Initialization.
+ //===----------------------------------------------------------------------===//
+ 
+ CompilerInvocationBase::CompilerInvocationBase()
+   : LangOpts(new LangOptions()), TargetOpts(new TargetOptions()),
+     DiagnosticOpts(new DiagnosticOptions()),
+     HeaderSearchOpts(new HeaderSearchOptions()),
+     PreprocessorOpts(new PreprocessorOptions()) {}
+ 
+ CompilerInvocationBase::CompilerInvocationBase(const CompilerInvocationBase &X)
+     : LangOpts(new LangOptions(*X.getLangOpts())),
+       TargetOpts(new TargetOptions(X.getTargetOpts())),
+       DiagnosticOpts(new DiagnosticOptions(X.getDiagnosticOpts())),
+       HeaderSearchOpts(new HeaderSearchOptions(X.getHeaderSearchOpts())),
+       PreprocessorOpts(new PreprocessorOptions(X.getPreprocessorOpts())) {}
+ 
+ CompilerInvocationBase::~CompilerInvocationBase() {}
+ 
+ //===----------------------------------------------------------------------===//
+ // Deserialization (from args)
+ //===----------------------------------------------------------------------===//
+ 
+ using namespace clang::driver;
+ using namespace clang::driver::options;
+ using namespace llvm::opt;
+ 
+ //
+ 
+ static unsigned getOptimizationLevel(ArgList &Args, InputKind IK,
+                                      DiagnosticsEngine &Diags) {
+   unsigned DefaultOpt = 0;
+   if (IK.getLanguage() == InputKind::OpenCL && !Args.hasArg(OPT_cl_opt_disable))
+     DefaultOpt = 2;
+ 
+   if (Arg *A = Args.getLastArg(options::OPT_O_Group)) {
+     if (A->getOption().matches(options::OPT_O0))
+       return 0;
+ 
+     if (A->getOption().matches(options::OPT_Ofast))
+       return 3;
+ 
+     assert (A->getOption().matches(options::OPT_O));
+ 
+     StringRef S(A->getValue());
+     if (S == "s" || S == "z" || S.empty())
+       return 2;
+ 
+     if (S == "g")
+       return 1;
+ 
+     return getLastArgIntValue(Args, OPT_O, DefaultOpt, Diags);
+   }
+ 
+   return DefaultOpt;
+ }
+ 
+ static unsigned getOptimizationLevelSize(ArgList &Args) {
+   if (Arg *A = Args.getLastArg(options::OPT_O_Group)) {
+     if (A->getOption().matches(options::OPT_O)) {
+       switch (A->getValue()[0]) {
+       default:
+         return 0;
+       case 's':
+         return 1;
+       case 'z':
+         return 2;
+       }
+     }
+   }
+   return 0;
+ }
+ 
+ static void addDiagnosticArgs(ArgList &Args, OptSpecifier Group,
+                               OptSpecifier GroupWithValue,
+                               std::vector<std::string> &Diagnostics) {
+   for (Arg *A : Args.filtered(Group)) {
+     if (A->getOption().getKind() == Option::FlagClass) {
+       // The argument is a pure flag (such as OPT_Wall or OPT_Wdeprecated). Add
+       // its name (minus the "W" or "R" at the beginning) to the warning list.
+       Diagnostics.push_back(A->getOption().getName().drop_front(1));
+     } else if (A->getOption().matches(GroupWithValue)) {
+       // This is -Wfoo= or -Rfoo=, where foo is the name of the diagnostic group.
+       Diagnostics.push_back(A->getOption().getName().drop_front(1).rtrim("=-"));
+     } else {
+       // Otherwise, add its value (for OPT_W_Joined and similar).
+       for (const char *Arg : A->getValues())
+         Diagnostics.emplace_back(Arg);
+     }
+   }
+ }
+ 
+ static void getAllNoBuiltinFuncValues(ArgList &Args,
+                                       std::vector<std::string> &Funcs) {
+   SmallVector<const char *, 8> Values;
+   for (const auto &Arg : Args) {
+     const Option &O = Arg->getOption();
+     if (O.matches(options::OPT_fno_builtin_)) {
+       const char *FuncName = Arg->getValue();
+       if (Builtin::Context::isBuiltinFunc(FuncName))
+         Values.push_back(FuncName);
+     }
+   }
+   Funcs.insert(Funcs.end(), Values.begin(), Values.end());
+ }
+ 
+ static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
+                               DiagnosticsEngine &Diags) {
+   using namespace options;
+   bool Success = true;
+   if (Arg *A = Args.getLastArg(OPT_analyzer_store)) {
+     StringRef Name = A->getValue();
+     AnalysisStores Value = llvm::StringSwitch<AnalysisStores>(Name)
+ #define ANALYSIS_STORE(NAME, CMDFLAG, DESC, CREATFN) \
+       .Case(CMDFLAG, NAME##Model)
+ #include "clang/StaticAnalyzer/Core/Analyses.def"
+       .Default(NumStores);
+     if (Value == NumStores) {
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << Name;
+       Success = false;
+     } else {
+       Opts.AnalysisStoreOpt = Value;
+     }
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_analyzer_constraints)) {
+     StringRef Name = A->getValue();
+     AnalysisConstraints Value = llvm::StringSwitch<AnalysisConstraints>(Name)
+ #define ANALYSIS_CONSTRAINTS(NAME, CMDFLAG, DESC, CREATFN) \
+       .Case(CMDFLAG, NAME##Model)
+ #include "clang/StaticAnalyzer/Core/Analyses.def"
+       .Default(NumConstraints);
+     if (Value == NumConstraints) {
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << Name;
+       Success = false;
+     } else {
+       Opts.AnalysisConstraintsOpt = Value;
+     }
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_analyzer_output)) {
+     StringRef Name = A->getValue();
+     AnalysisDiagClients Value = llvm::StringSwitch<AnalysisDiagClients>(Name)
+ #define ANALYSIS_DIAGNOSTICS(NAME, CMDFLAG, DESC, CREATFN) \
+       .Case(CMDFLAG, PD_##NAME)
+ #include "clang/StaticAnalyzer/Core/Analyses.def"
+       .Default(NUM_ANALYSIS_DIAG_CLIENTS);
+     if (Value == NUM_ANALYSIS_DIAG_CLIENTS) {
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << Name;
+       Success = false;
+     } else {
+       Opts.AnalysisDiagOpt = Value;
+     }
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_analyzer_purge)) {
+     StringRef Name = A->getValue();
+     AnalysisPurgeMode Value = llvm::StringSwitch<AnalysisPurgeMode>(Name)
+ #define ANALYSIS_PURGE(NAME, CMDFLAG, DESC) \
+       .Case(CMDFLAG, NAME)
+ #include "clang/StaticAnalyzer/Core/Analyses.def"
+       .Default(NumPurgeModes);
+     if (Value == NumPurgeModes) {
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << Name;
+       Success = false;
+     } else {
+       Opts.AnalysisPurgeOpt = Value;
+     }
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_analyzer_inlining_mode)) {
+     StringRef Name = A->getValue();
+     AnalysisInliningMode Value = llvm::StringSwitch<AnalysisInliningMode>(Name)
+ #define ANALYSIS_INLINING_MODE(NAME, CMDFLAG, DESC) \
+       .Case(CMDFLAG, NAME)
+ #include "clang/StaticAnalyzer/Core/Analyses.def"
+       .Default(NumInliningModes);
+     if (Value == NumInliningModes) {
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << Name;
+       Success = false;
+     } else {
+       Opts.InliningMode = Value;
+     }
+   }
+ 
+   Opts.ShowCheckerHelp = Args.hasArg(OPT_analyzer_checker_help);
+   Opts.ShowEnabledCheckerList = Args.hasArg(OPT_analyzer_list_enabled_checkers);
+   Opts.DisableAllChecks = Args.hasArg(OPT_analyzer_disable_all_checks);
+ 
+   Opts.visualizeExplodedGraphWithGraphViz =
+     Args.hasArg(OPT_analyzer_viz_egraph_graphviz);
+   Opts.visualizeExplodedGraphWithUbiGraph =
+     Args.hasArg(OPT_analyzer_viz_egraph_ubigraph);
+   Opts.NoRetryExhausted = Args.hasArg(OPT_analyzer_disable_retry_exhausted);
+   Opts.AnalyzeAll = Args.hasArg(OPT_analyzer_opt_analyze_headers);
+   Opts.AnalyzerDisplayProgress = Args.hasArg(OPT_analyzer_display_progress);
+   Opts.AnalyzeNestedBlocks =
+     Args.hasArg(OPT_analyzer_opt_analyze_nested_blocks);
+   Opts.eagerlyAssumeBinOpBifurcation = Args.hasArg(OPT_analyzer_eagerly_assume);
+   Opts.AnalyzeSpecificFunction = Args.getLastArgValue(OPT_analyze_function);
+   Opts.UnoptimizedCFG = Args.hasArg(OPT_analysis_UnoptimizedCFG);
+   Opts.TrimGraph = Args.hasArg(OPT_trim_egraph);
+   Opts.maxBlockVisitOnPath =
+       getLastArgIntValue(Args, OPT_analyzer_max_loop, 4, Diags);
+   Opts.PrintStats = Args.hasArg(OPT_analyzer_stats);
+   Opts.InlineMaxStackDepth =
+       getLastArgIntValue(Args, OPT_analyzer_inline_max_stack_depth,
+                          Opts.InlineMaxStackDepth, Diags);
+ 
+   Opts.CheckersControlList.clear();
+   for (const Arg *A :
+        Args.filtered(OPT_analyzer_checker, OPT_analyzer_disable_checker)) {
+     A->claim();
+     bool enable = (A->getOption().getID() == OPT_analyzer_checker);
+     // We can have a list of comma separated checker names, e.g:
+     // '-analyzer-checker=cocoa,unix'
+     StringRef checkerList = A->getValue();
+     SmallVector<StringRef, 4> checkers;
+     checkerList.split(checkers, ",");
+     for (StringRef checker : checkers)
+       Opts.CheckersControlList.emplace_back(checker, enable);
+   }
+ 
+   // Go through the analyzer configuration options.
+   for (const Arg *A : Args.filtered(OPT_analyzer_config)) {
+     A->claim();
+     // We can have a list of comma separated config names, e.g:
+     // '-analyzer-config key1=val1,key2=val2'
+     StringRef configList = A->getValue();
+     SmallVector<StringRef, 4> configVals;
+     configList.split(configVals, ",");
+     for (unsigned i = 0, e = configVals.size(); i != e; ++i) {
+       StringRef key, val;
+       std::tie(key, val) = configVals[i].split("=");
+       if (val.empty()) {
+         Diags.Report(SourceLocation(),
+                      diag::err_analyzer_config_no_value) << configVals[i];
+         Success = false;
+         break;
+       }
+       if (val.find('=') != StringRef::npos) {
+         Diags.Report(SourceLocation(),
+                      diag::err_analyzer_config_multiple_values)
+           << configVals[i];
+         Success = false;
+         break;
+       }
+       Opts.Config[key] = val;
+     }
+   }
+ 
+   llvm::raw_string_ostream os(Opts.FullCompilerInvocation);
+   for (unsigned i=0; i<Args.getNumInputArgStrings(); i++) {
+     if (i != 0)
+       os << " ";
+     os << Args.getArgString(i);
+   }
+   os.flush();
+ 
+   return Success;
+ }
+ 
+ static bool ParseMigratorArgs(MigratorOptions &Opts, ArgList &Args) {
+   Opts.NoNSAllocReallocError = Args.hasArg(OPT_migrator_no_nsalloc_error);
+   Opts.NoFinalizeRemoval = Args.hasArg(OPT_migrator_no_finalize_removal);
+   return true;
+ }
+ 
+ static void ParseCommentArgs(CommentOptions &Opts, ArgList &Args) {
+   Opts.BlockCommandNames = Args.getAllArgValues(OPT_fcomment_block_commands);
+   Opts.ParseAllComments = Args.hasArg(OPT_fparse_all_comments);
+ }
+ 
+ static StringRef getCodeModel(ArgList &Args, DiagnosticsEngine &Diags) {
+   if (Arg *A = Args.getLastArg(OPT_mcode_model)) {
+     StringRef Value = A->getValue();
+     if (Value == "small" || Value == "kernel" || Value == "medium" ||
+         Value == "large")
+       return Value;
+     Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Value;
+   }
+   return "default";
+ }
+ 
+ static llvm::Reloc::Model getRelocModel(ArgList &Args,
+                                         DiagnosticsEngine &Diags) {
+   if (Arg *A = Args.getLastArg(OPT_mrelocation_model)) {
+     StringRef Value = A->getValue();
+     auto RM = llvm::StringSwitch<llvm::Optional<llvm::Reloc::Model>>(Value)
+                   .Case("static", llvm::Reloc::Static)
+                   .Case("pic", llvm::Reloc::PIC_)
+                   .Case("ropi", llvm::Reloc::ROPI)
+                   .Case("rwpi", llvm::Reloc::RWPI)
+                   .Case("ropi-rwpi", llvm::Reloc::ROPI_RWPI)
+                   .Case("dynamic-no-pic", llvm::Reloc::DynamicNoPIC)
+                   .Default(None);
+     if (RM.hasValue())
+       return *RM;
+     Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Value;
+   }
+   return llvm::Reloc::PIC_;
+ }
+ 
+ /// \brief Create a new Regex instance out of the string value in \p RpassArg.
+ /// It returns a pointer to the newly generated Regex instance.
+ static std::shared_ptr<llvm::Regex>
+ GenerateOptimizationRemarkRegex(DiagnosticsEngine &Diags, ArgList &Args,
+                                 Arg *RpassArg) {
+   StringRef Val = RpassArg->getValue();
+   std::string RegexError;
+   std::shared_ptr<llvm::Regex> Pattern = std::make_shared<llvm::Regex>(Val);
+   if (!Pattern->isValid(RegexError)) {
+     Diags.Report(diag::err_drv_optimization_remark_pattern)
+         << RegexError << RpassArg->getAsString(Args);
+     Pattern.reset();
+   }
+   return Pattern;
+ }
+ 
+ static bool parseDiagnosticLevelMask(StringRef FlagName,
+                                      const std::vector<std::string> &Levels,
+                                      DiagnosticsEngine *Diags,
+                                      DiagnosticLevelMask &M) {
+   bool Success = true;
+   for (const auto &Level : Levels) {
+     DiagnosticLevelMask const PM =
+       llvm::StringSwitch<DiagnosticLevelMask>(Level)
+         .Case("note",    DiagnosticLevelMask::Note)
+         .Case("remark",  DiagnosticLevelMask::Remark)
+         .Case("warning", DiagnosticLevelMask::Warning)
+         .Case("error",   DiagnosticLevelMask::Error)
+         .Default(DiagnosticLevelMask::None);
+     if (PM == DiagnosticLevelMask::None) {
+       Success = false;
+       if (Diags)
+         Diags->Report(diag::err_drv_invalid_value) << FlagName << Level;
+     }
+     M = M | PM;
+   }
+   return Success;
+ }
+ 
+ static void parseSanitizerKinds(StringRef FlagName,
+                                 const std::vector<std::string> &Sanitizers,
+                                 DiagnosticsEngine &Diags, SanitizerSet &S) {
+   for (const auto &Sanitizer : Sanitizers) {
+     SanitizerMask K = parseSanitizerValue(Sanitizer, /*AllowGroups=*/false);
+     if (K == 0)
+       Diags.Report(diag::err_drv_invalid_value) << FlagName << Sanitizer;
+     else
+       S.set(K, true);
+   }
+ }
+ 
+ // Set the profile kind for fprofile-instrument.
+ static void setPGOInstrumentor(CodeGenOptions &Opts, ArgList &Args,
+                                DiagnosticsEngine &Diags) {
+   Arg *A = Args.getLastArg(OPT_fprofile_instrument_EQ);
+   if (A == nullptr)
+     return;
+   StringRef S = A->getValue();
+   unsigned I = llvm::StringSwitch<unsigned>(S)
+                    .Case("none", CodeGenOptions::ProfileNone)
+                    .Case("clang", CodeGenOptions::ProfileClangInstr)
+                    .Case("llvm", CodeGenOptions::ProfileIRInstr)
+                    .Default(~0U);
+   if (I == ~0U) {
+     Diags.Report(diag::err_drv_invalid_pgo_instrumentor) << A->getAsString(Args)
+                                                          << S;
+     return;
+   }
+   CodeGenOptions::ProfileInstrKind Instrumentor =
+       static_cast<CodeGenOptions::ProfileInstrKind>(I);
+   Opts.setProfileInstr(Instrumentor);
+ }
+ 
+ // Set the profile kind using fprofile-instrument-use-path.
+ static void setPGOUseInstrumentor(CodeGenOptions &Opts,
+                                   const Twine &ProfileName) {
+   auto ReaderOrErr = llvm::IndexedInstrProfReader::create(ProfileName);
+   // In error, return silently and let Clang PGOUse report the error message.
+   if (auto E = ReaderOrErr.takeError()) {
+     llvm::consumeError(std::move(E));
+     Opts.setProfileUse(CodeGenOptions::ProfileClangInstr);
+     return;
+   }
+   std::unique_ptr<llvm::IndexedInstrProfReader> PGOReader =
+     std::move(ReaderOrErr.get());
+   if (PGOReader->isIRLevelProfile())
+     Opts.setProfileUse(CodeGenOptions::ProfileIRInstr);
+   else
+     Opts.setProfileUse(CodeGenOptions::ProfileClangInstr);
+ }
+ 
+ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
+                              DiagnosticsEngine &Diags,
+                              const TargetOptions &TargetOpts) {
+   using namespace options;
+   bool Success = true;
+   llvm::Triple Triple = llvm::Triple(TargetOpts.Triple);
+ 
+   unsigned OptimizationLevel = getOptimizationLevel(Args, IK, Diags);
+   // TODO: This could be done in Driver
+   unsigned MaxOptLevel = 3;
+   if (OptimizationLevel > MaxOptLevel) {
+     // If the optimization level is not supported, fall back on the default
+     // optimization
+     Diags.Report(diag::warn_drv_optimization_value)
+         << Args.getLastArg(OPT_O)->getAsString(Args) << "-O" << MaxOptLevel;
+     OptimizationLevel = MaxOptLevel;
+   }
+   Opts.OptimizationLevel = OptimizationLevel;
+ 
+   // At O0 we want to fully disable inlining outside of cases marked with
+   // 'alwaysinline' that are required for correctness.
+   Opts.setInlining((Opts.OptimizationLevel == 0)
+                        ? CodeGenOptions::OnlyAlwaysInlining
+                        : CodeGenOptions::NormalInlining);
+   // Explicit inlining flags can disable some or all inlining even at
+   // optimization levels above zero.
+   if (Arg *InlineArg = Args.getLastArg(
+           options::OPT_finline_functions, options::OPT_finline_hint_functions,
+           options::OPT_fno_inline_functions, options::OPT_fno_inline)) {
+     if (Opts.OptimizationLevel > 0) {
+       const Option &InlineOpt = InlineArg->getOption();
+       if (InlineOpt.matches(options::OPT_finline_functions))
+         Opts.setInlining(CodeGenOptions::NormalInlining);
+       else if (InlineOpt.matches(options::OPT_finline_hint_functions))
+         Opts.setInlining(CodeGenOptions::OnlyHintInlining);
+       else
+         Opts.setInlining(CodeGenOptions::OnlyAlwaysInlining);
+     }
+   }
+ 
+   Opts.ExperimentalNewPassManager = Args.hasFlag(
+       OPT_fexperimental_new_pass_manager, OPT_fno_experimental_new_pass_manager,
+       /* Default */ false);
+ 
+   Opts.DebugPassManager =
+       Args.hasFlag(OPT_fdebug_pass_manager, OPT_fno_debug_pass_manager,
+                    /* Default */ false);
+ 
+   if (Arg *A = Args.getLastArg(OPT_fveclib)) {
+     StringRef Name = A->getValue();
+     if (Name == "Accelerate")
+       Opts.setVecLib(CodeGenOptions::Accelerate);
+     else if (Name == "SVML")
+       Opts.setVecLib(CodeGenOptions::SVML);
+     else if (Name == "none")
+       Opts.setVecLib(CodeGenOptions::NoLibrary);
+     else
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Name;
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_debug_info_kind_EQ)) {
+     unsigned Val =
+         llvm::StringSwitch<unsigned>(A->getValue())
+             .Case("line-tables-only", codegenoptions::DebugLineTablesOnly)
+             .Case("limited", codegenoptions::LimitedDebugInfo)
+             .Case("standalone", codegenoptions::FullDebugInfo)
+             .Default(~0U);
+     if (Val == ~0U)
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args)
+                                                 << A->getValue();
+     else
+       Opts.setDebugInfo(static_cast<codegenoptions::DebugInfoKind>(Val));
+   }
+   if (Arg *A = Args.getLastArg(OPT_debugger_tuning_EQ)) {
+     unsigned Val = llvm::StringSwitch<unsigned>(A->getValue())
+                        .Case("gdb", unsigned(llvm::DebuggerKind::GDB))
+                        .Case("lldb", unsigned(llvm::DebuggerKind::LLDB))
+                        .Case("sce", unsigned(llvm::DebuggerKind::SCE))
+                        .Default(~0U);
+     if (Val == ~0U)
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args)
+                                                 << A->getValue();
+     else
+       Opts.setDebuggerTuning(static_cast<llvm::DebuggerKind>(Val));
+   }
+   Opts.DwarfVersion = getLastArgIntValue(Args, OPT_dwarf_version_EQ, 0, Diags);
+   Opts.DebugColumnInfo = Args.hasArg(OPT_dwarf_column_info);
+   Opts.EmitCodeView = Args.hasArg(OPT_gcodeview);
+   Opts.MacroDebugInfo = Args.hasArg(OPT_debug_info_macro);
+   Opts.WholeProgramVTables = Args.hasArg(OPT_fwhole_program_vtables);
+   Opts.LTOVisibilityPublicStd = Args.hasArg(OPT_flto_visibility_public_std);
+   Opts.EnableSplitDwarf = Args.hasArg(OPT_enable_split_dwarf);
+   Opts.SplitDwarfFile = Args.getLastArgValue(OPT_split_dwarf_file);
+   Opts.SplitDwarfInlining = !Args.hasArg(OPT_fno_split_dwarf_inlining);
+   Opts.DebugTypeExtRefs = Args.hasArg(OPT_dwarf_ext_refs);
+   Opts.DebugExplicitImport = Args.hasArg(OPT_dwarf_explicit_import);
+   Opts.DebugFwdTemplateParams = Args.hasArg(OPT_debug_forward_template_params);
+ 
+   for (const auto &Arg : Args.getAllArgValues(OPT_fdebug_prefix_map_EQ))
+     Opts.DebugPrefixMap.insert(StringRef(Arg).split('='));
+ 
+   if (const Arg *A =
+           Args.getLastArg(OPT_emit_llvm_uselists, OPT_no_emit_llvm_uselists))
+     Opts.EmitLLVMUseLists = A->getOption().getID() == OPT_emit_llvm_uselists;
+ 
+   Opts.DisableLLVMPasses = Args.hasArg(OPT_disable_llvm_passes);
+   Opts.DisableLifetimeMarkers = Args.hasArg(OPT_disable_lifetimemarkers);
+   Opts.DisableO0ImplyOptNone = Args.hasArg(OPT_disable_O0_optnone);
+   Opts.DisableRedZone = Args.hasArg(OPT_disable_red_zone);
+   Opts.ForbidGuardVariables = Args.hasArg(OPT_fforbid_guard_variables);
+   Opts.UseRegisterSizedBitfieldAccess = Args.hasArg(
+     OPT_fuse_register_sized_bitfield_access);
+   Opts.RelaxedAliasing = Args.hasArg(OPT_relaxed_aliasing);
+   Opts.StructPathTBAA = !Args.hasArg(OPT_no_struct_path_tbaa);
+   Opts.NewStructPathTBAA = !Args.hasArg(OPT_no_struct_path_tbaa) &&
+                            Args.hasArg(OPT_new_struct_path_tbaa);
+   Opts.FineGrainedBitfieldAccesses =
+       Args.hasFlag(OPT_ffine_grained_bitfield_accesses,
+                    OPT_fno_fine_grained_bitfield_accesses, false);
+   Opts.DwarfDebugFlags = Args.getLastArgValue(OPT_dwarf_debug_flags);
+   Opts.MergeAllConstants = !Args.hasArg(OPT_fno_merge_all_constants);
+   Opts.NoCommon = Args.hasArg(OPT_fno_common);
+   Opts.NoImplicitFloat = Args.hasArg(OPT_no_implicit_float);
+   Opts.OptimizeSize = getOptimizationLevelSize(Args);
+   Opts.SimplifyLibCalls = !(Args.hasArg(OPT_fno_builtin) ||
+                             Args.hasArg(OPT_ffreestanding));
+   if (Opts.SimplifyLibCalls)
+     getAllNoBuiltinFuncValues(Args, Opts.NoBuiltinFuncs);
+   Opts.UnrollLoops =
+       Args.hasFlag(OPT_funroll_loops, OPT_fno_unroll_loops,
+                    (Opts.OptimizationLevel > 1));
+   Opts.RerollLoops = Args.hasArg(OPT_freroll_loops);
+ 
+   Opts.DisableIntegratedAS = Args.hasArg(OPT_fno_integrated_as);
+   Opts.Autolink = !Args.hasArg(OPT_fno_autolink);
+   Opts.SampleProfileFile = Args.getLastArgValue(OPT_fprofile_sample_use_EQ);
+   Opts.DebugInfoForProfiling = Args.hasFlag(
+       OPT_fdebug_info_for_profiling, OPT_fno_debug_info_for_profiling, false);
+   Opts.GnuPubnames = Args.hasArg(OPT_ggnu_pubnames);
+ 
+   setPGOInstrumentor(Opts, Args, Diags);
+   Opts.InstrProfileOutput =
+       Args.getLastArgValue(OPT_fprofile_instrument_path_EQ);
+   Opts.ProfileInstrumentUsePath =
+       Args.getLastArgValue(OPT_fprofile_instrument_use_path_EQ);
+   if (!Opts.ProfileInstrumentUsePath.empty())
+     setPGOUseInstrumentor(Opts, Opts.ProfileInstrumentUsePath);
+ 
+   if (Arg *A = Args.getLastArg(OPT_fclang_abi_compat_EQ)) {
+     Opts.setClangABICompat(CodeGenOptions::ClangABI::Latest);
+ 
+     StringRef Ver = A->getValue();
+     std::pair<StringRef, StringRef> VerParts = Ver.split('.');
+     unsigned Major, Minor = 0;
+ 
+     // Check the version number is valid: either 3.x (0 <= x <= 9) or
+     // y or y.0 (4 <= y <= current version).
+     if (!VerParts.first.startswith("0") &&
+         !VerParts.first.getAsInteger(10, Major) &&
+         3 <= Major && Major <= CLANG_VERSION_MAJOR &&
+         (Major == 3 ? VerParts.second.size() == 1 &&
+                       !VerParts.second.getAsInteger(10, Minor)
+                     : VerParts.first.size() == Ver.size() ||
+                       VerParts.second == "0")) {
+       // Got a valid version number.
+       if (Major == 3 && Minor <= 8)
+         Opts.setClangABICompat(CodeGenOptions::ClangABI::Ver3_8);
+       else if (Major <= 4)
+         Opts.setClangABICompat(CodeGenOptions::ClangABI::Ver4);
+     } else if (Ver != "latest") {
+       Diags.Report(diag::err_drv_invalid_value)
+           << A->getAsString(Args) << A->getValue();
+     }
+   }
+ 
+   Opts.CoverageMapping =
+       Args.hasFlag(OPT_fcoverage_mapping, OPT_fno_coverage_mapping, false);
+   Opts.DumpCoverageMapping = Args.hasArg(OPT_dump_coverage_mapping);
+   Opts.AsmVerbose = Args.hasArg(OPT_masm_verbose);
+   Opts.PreserveAsmComments = !Args.hasArg(OPT_fno_preserve_as_comments);
+   Opts.AssumeSaneOperatorNew = !Args.hasArg(OPT_fno_assume_sane_operator_new);
+   Opts.ObjCAutoRefCountExceptions = Args.hasArg(OPT_fobjc_arc_exceptions);
+   Opts.CXAAtExit = !Args.hasArg(OPT_fno_use_cxa_atexit);
+   Opts.CXXCtorDtorAliases = Args.hasArg(OPT_mconstructor_aliases);
+   Opts.CodeModel = getCodeModel(Args, Diags);
+   Opts.DebugPass = Args.getLastArgValue(OPT_mdebug_pass);
+   Opts.DisableFPElim =
+       (Args.hasArg(OPT_mdisable_fp_elim) || Args.hasArg(OPT_pg));
+   Opts.DisableFree = Args.hasArg(OPT_disable_free);
+   Opts.DiscardValueNames = Args.hasArg(OPT_discard_value_names);
+   Opts.DisableTailCalls = Args.hasArg(OPT_mdisable_tail_calls);
+   Opts.FloatABI = Args.getLastArgValue(OPT_mfloat_abi);
+   Opts.LessPreciseFPMAD = Args.hasArg(OPT_cl_mad_enable) ||
+                           Args.hasArg(OPT_cl_unsafe_math_optimizations) ||
+                           Args.hasArg(OPT_cl_fast_relaxed_math);
+   Opts.LimitFloatPrecision = Args.getLastArgValue(OPT_mlimit_float_precision);
+   Opts.NoInfsFPMath = (Args.hasArg(OPT_menable_no_infinities) ||
+                        Args.hasArg(OPT_cl_finite_math_only) ||
+                        Args.hasArg(OPT_cl_fast_relaxed_math));
+   Opts.NoNaNsFPMath = (Args.hasArg(OPT_menable_no_nans) ||
+                        Args.hasArg(OPT_cl_unsafe_math_optimizations) ||
+                        Args.hasArg(OPT_cl_finite_math_only) ||
+                        Args.hasArg(OPT_cl_fast_relaxed_math));
+   Opts.NoSignedZeros = (Args.hasArg(OPT_fno_signed_zeros) ||
+                         Args.hasArg(OPT_cl_no_signed_zeros) ||
+                         Args.hasArg(OPT_cl_unsafe_math_optimizations) ||
+                         Args.hasArg(OPT_cl_fast_relaxed_math));
+   Opts.Reassociate = Args.hasArg(OPT_mreassociate);
+   Opts.FlushDenorm = Args.hasArg(OPT_cl_denorms_are_zero);
+   Opts.CorrectlyRoundedDivSqrt =
+       Args.hasArg(OPT_cl_fp32_correctly_rounded_divide_sqrt);
+   Opts.Reciprocals = Args.getAllArgValues(OPT_mrecip_EQ);
+   Opts.ReciprocalMath = Args.hasArg(OPT_freciprocal_math);
+   Opts.NoTrappingMath = Args.hasArg(OPT_fno_trapping_math);
+   Opts.NoZeroInitializedInBSS = Args.hasArg(OPT_mno_zero_initialized_in_bss);
+   Opts.BackendOptions = Args.getAllArgValues(OPT_backend_option);
+   Opts.NumRegisterParameters = getLastArgIntValue(Args, OPT_mregparm, 0, Diags);
+   Opts.NoExecStack = Args.hasArg(OPT_mno_exec_stack);
+   Opts.FatalWarnings = Args.hasArg(OPT_massembler_fatal_warnings);
+   Opts.EnableSegmentedStacks = Args.hasArg(OPT_split_stacks);
+   Opts.RelaxAll = Args.hasArg(OPT_mrelax_all);
+   Opts.IncrementalLinkerCompatible =
+       Args.hasArg(OPT_mincremental_linker_compatible);
+   Opts.PIECopyRelocations =
+       Args.hasArg(OPT_mpie_copy_relocations);
+   Opts.NoPLT = Args.hasArg(OPT_fno_plt);
+   Opts.OmitLeafFramePointer = Args.hasArg(OPT_momit_leaf_frame_pointer);
+   Opts.SaveTempLabels = Args.hasArg(OPT_msave_temp_labels);
+   Opts.NoDwarfDirectoryAsm = Args.hasArg(OPT_fno_dwarf_directory_asm);
+   Opts.SoftFloat = Args.hasArg(OPT_msoft_float);
+   Opts.StrictEnums = Args.hasArg(OPT_fstrict_enums);
+   Opts.StrictReturn = !Args.hasArg(OPT_fno_strict_return);
+   Opts.StrictVTablePointers = Args.hasArg(OPT_fstrict_vtable_pointers);
+   Opts.UnsafeFPMath = Args.hasArg(OPT_menable_unsafe_fp_math) ||
+                       Args.hasArg(OPT_cl_unsafe_math_optimizations) ||
+                       Args.hasArg(OPT_cl_fast_relaxed_math);
+   Opts.UnwindTables = Args.hasArg(OPT_munwind_tables);
+   Opts.RelocationModel = getRelocModel(Args, Diags);
+   Opts.ThreadModel = Args.getLastArgValue(OPT_mthread_model, "posix");
+   if (Opts.ThreadModel != "posix" && Opts.ThreadModel != "single")
+     Diags.Report(diag::err_drv_invalid_value)
+         << Args.getLastArg(OPT_mthread_model)->getAsString(Args)
+         << Opts.ThreadModel;
+   Opts.TrapFuncName = Args.getLastArgValue(OPT_ftrap_function_EQ);
+   Opts.UseInitArray = Args.hasArg(OPT_fuse_init_array);
+ 
+   Opts.FunctionSections = Args.hasFlag(OPT_ffunction_sections,
+                                        OPT_fno_function_sections, false);
+   Opts.DataSections = Args.hasFlag(OPT_fdata_sections,
+                                    OPT_fno_data_sections, false);
+   Opts.StackSizeSection =
+       Args.hasFlag(OPT_fstack_size_section, OPT_fno_stack_size_section, false);
+   Opts.UniqueSectionNames = Args.hasFlag(OPT_funique_section_names,
+                                          OPT_fno_unique_section_names, true);
+ 
+   Opts.MergeFunctions = Args.hasArg(OPT_fmerge_functions);
+ 
+   Opts.NoUseJumpTables = Args.hasArg(OPT_fno_jump_tables);
+ 
+   Opts.ProfileSampleAccurate = Args.hasArg(OPT_fprofile_sample_accurate);
+ 
+   Opts.PrepareForLTO = Args.hasArg(OPT_flto, OPT_flto_EQ);
+   Opts.EmitSummaryIndex = false;
+   if (Arg *A = Args.getLastArg(OPT_flto_EQ)) {
+     StringRef S = A->getValue();
+     if (S == "thin")
+       Opts.EmitSummaryIndex = true;
+     else if (S != "full")
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << S;
+   }
+   Opts.LTOUnit = Args.hasFlag(OPT_flto_unit, OPT_fno_lto_unit, false);
+   if (Arg *A = Args.getLastArg(OPT_fthinlto_index_EQ)) {
+     if (IK.getLanguage() != InputKind::LLVM_IR)
+       Diags.Report(diag::err_drv_argument_only_allowed_with)
+           << A->getAsString(Args) << "-x ir";
+     Opts.ThinLTOIndexFile = Args.getLastArgValue(OPT_fthinlto_index_EQ);
+   }
+   Opts.ThinLinkBitcodeFile = Args.getLastArgValue(OPT_fthin_link_bitcode_EQ);
+ 
+   Opts.MSVolatile = Args.hasArg(OPT_fms_volatile);
+ 
+   Opts.VectorizeLoop = Args.hasArg(OPT_vectorize_loops);
+   Opts.VectorizeSLP = Args.hasArg(OPT_vectorize_slp);
+ 
+   Opts.PreferVectorWidth = Args.getLastArgValue(OPT_mprefer_vector_width_EQ);
+ 
+   Opts.MainFileName = Args.getLastArgValue(OPT_main_file_name);
+   Opts.VerifyModule = !Args.hasArg(OPT_disable_llvm_verifier);
+ 
+   Opts.ControlFlowGuard = Args.hasArg(OPT_cfguard);
+ 
+   Opts.DisableGCov = Args.hasArg(OPT_test_coverage);
+   Opts.EmitGcovArcs = Args.hasArg(OPT_femit_coverage_data);
+   Opts.EmitGcovNotes = Args.hasArg(OPT_femit_coverage_notes);
+   if (Opts.EmitGcovArcs || Opts.EmitGcovNotes) {
+     Opts.CoverageDataFile = Args.getLastArgValue(OPT_coverage_data_file);
+     Opts.CoverageNotesFile = Args.getLastArgValue(OPT_coverage_notes_file);
+     Opts.CoverageExtraChecksum = Args.hasArg(OPT_coverage_cfg_checksum);
+     Opts.CoverageNoFunctionNamesInData =
+         Args.hasArg(OPT_coverage_no_function_names_in_data);
+     Opts.CoverageExitBlockBeforeBody =
+         Args.hasArg(OPT_coverage_exit_block_before_body);
+     if (Args.hasArg(OPT_coverage_version_EQ)) {
+       StringRef CoverageVersion = Args.getLastArgValue(OPT_coverage_version_EQ);
+       if (CoverageVersion.size() != 4) {
+         Diags.Report(diag::err_drv_invalid_value)
+             << Args.getLastArg(OPT_coverage_version_EQ)->getAsString(Args)
+             << CoverageVersion;
+       } else {
+         memcpy(Opts.CoverageVersion, CoverageVersion.data(), 4);
+       }
+     }
+   }
+ 	// Handle -fembed-bitcode option.
+   if (Arg *A = Args.getLastArg(OPT_fembed_bitcode_EQ)) {
+     StringRef Name = A->getValue();
+     unsigned Model = llvm::StringSwitch<unsigned>(Name)
+         .Case("off", CodeGenOptions::Embed_Off)
+         .Case("all", CodeGenOptions::Embed_All)
+         .Case("bitcode", CodeGenOptions::Embed_Bitcode)
+         .Case("marker", CodeGenOptions::Embed_Marker)
+         .Default(~0U);
+     if (Model == ~0U) {
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Name;
+       Success = false;
+     } else
+       Opts.setEmbedBitcode(
+           static_cast<CodeGenOptions::EmbedBitcodeKind>(Model));
+   }
+   // FIXME: For backend options that are not yet recorded as function
+   // attributes in the IR, keep track of them so we can embed them in a
+   // separate data section and use them when building the bitcode.
+   if (Opts.getEmbedBitcode() == CodeGenOptions::Embed_All) {
+     for (const auto &A : Args) {
+       // Do not encode output and input.
+       if (A->getOption().getID() == options::OPT_o ||
+           A->getOption().getID() == options::OPT_INPUT ||
+           A->getOption().getID() == options::OPT_x ||
+           A->getOption().getID() == options::OPT_fembed_bitcode ||
+           (A->getOption().getGroup().isValid() &&
+            A->getOption().getGroup().getID() == options::OPT_W_Group))
+         continue;
+       ArgStringList ASL;
+       A->render(Args, ASL);
+       for (const auto &arg : ASL) {
+         StringRef ArgStr(arg);
+         Opts.CmdArgs.insert(Opts.CmdArgs.end(), ArgStr.begin(), ArgStr.end());
+         // using \00 to seperate each commandline options.
+         Opts.CmdArgs.push_back('\0');
+       }
+     }
+   }
+ 
+   Opts.PreserveVec3Type = Args.hasArg(OPT_fpreserve_vec3_type);
+   Opts.InstrumentFunctions = Args.hasArg(OPT_finstrument_functions);
+   Opts.InstrumentFunctionsAfterInlining =
+       Args.hasArg(OPT_finstrument_functions_after_inlining);
+   Opts.InstrumentFunctionEntryBare =
+       Args.hasArg(OPT_finstrument_function_entry_bare);
+   Opts.XRayInstrumentFunctions = Args.hasArg(OPT_fxray_instrument);
+   Opts.XRayAlwaysEmitCustomEvents =
+       Args.hasArg(OPT_fxray_always_emit_customevents);
+   Opts.XRayInstructionThreshold =
+       getLastArgIntValue(Args, OPT_fxray_instruction_threshold_EQ, 200, Diags);
+   Opts.InstrumentForProfiling = Args.hasArg(OPT_pg);
+   Opts.CallFEntry = Args.hasArg(OPT_mfentry);
+   Opts.EmitOpenCLArgMetadata = Args.hasArg(OPT_cl_kernel_arg_info);
+ 
+   if (const Arg *A = Args.getLastArg(OPT_fcf_protection_EQ)) {
+     StringRef Name = A->getValue();
+     if (Name == "full") {
+       Opts.CFProtectionReturn = 1;
+       Opts.CFProtectionBranch = 1;
+     } else if (Name == "return")
+       Opts.CFProtectionReturn = 1;
+     else if (Name == "branch")
+       Opts.CFProtectionBranch = 1;
+     else if (Name != "none") {
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Name;
+       Success = false;
+     }
+   }
+ 
+   if (const Arg *A = Args.getLastArg(OPT_compress_debug_sections,
+                                      OPT_compress_debug_sections_EQ)) {
+     if (A->getOption().getID() == OPT_compress_debug_sections) {
+       // TODO: be more clever about the compression type auto-detection
+       Opts.setCompressDebugSections(llvm::DebugCompressionType::GNU);
+     } else {
+       auto DCT = llvm::StringSwitch<llvm::DebugCompressionType>(A->getValue())
+                      .Case("none", llvm::DebugCompressionType::None)
+                      .Case("zlib", llvm::DebugCompressionType::Z)
+                      .Case("zlib-gnu", llvm::DebugCompressionType::GNU)
+                      .Default(llvm::DebugCompressionType::None);
+       Opts.setCompressDebugSections(DCT);
+     }
+   }
+ 
+   Opts.RelaxELFRelocations = Args.hasArg(OPT_mrelax_relocations);
+   Opts.DebugCompilationDir = Args.getLastArgValue(OPT_fdebug_compilation_dir);
+   for (auto A : Args.filtered(OPT_mlink_bitcode_file, OPT_mlink_cuda_bitcode)) {
+     CodeGenOptions::BitcodeFileToLink F;
+     F.Filename = A->getValue();
+     if (A->getOption().matches(OPT_mlink_cuda_bitcode)) {
+       F.LinkFlags = llvm::Linker::Flags::LinkOnlyNeeded;
+       // When linking CUDA bitcode, propagate function attributes so that
+       // e.g. libdevice gets fast-math attrs if we're building with fast-math.
+       F.PropagateAttrs = true;
+       F.Internalize = true;
+     }
+     Opts.LinkBitcodeFiles.push_back(F);
+   }
+   Opts.SanitizeCoverageType =
+       getLastArgIntValue(Args, OPT_fsanitize_coverage_type, 0, Diags);
+   Opts.SanitizeCoverageIndirectCalls =
+       Args.hasArg(OPT_fsanitize_coverage_indirect_calls);
+   Opts.SanitizeCoverageTraceBB = Args.hasArg(OPT_fsanitize_coverage_trace_bb);
+   Opts.SanitizeCoverageTraceCmp = Args.hasArg(OPT_fsanitize_coverage_trace_cmp);
+   Opts.SanitizeCoverageTraceDiv = Args.hasArg(OPT_fsanitize_coverage_trace_div);
+   Opts.SanitizeCoverageTraceGep = Args.hasArg(OPT_fsanitize_coverage_trace_gep);
+   Opts.SanitizeCoverage8bitCounters =
+       Args.hasArg(OPT_fsanitize_coverage_8bit_counters);
+   Opts.SanitizeCoverageTracePC = Args.hasArg(OPT_fsanitize_coverage_trace_pc);
+   Opts.SanitizeCoverageTracePCGuard =
+       Args.hasArg(OPT_fsanitize_coverage_trace_pc_guard);
+   Opts.SanitizeCoverageNoPrune = Args.hasArg(OPT_fsanitize_coverage_no_prune);
+   Opts.SanitizeCoverageInline8bitCounters =
+       Args.hasArg(OPT_fsanitize_coverage_inline_8bit_counters);
+   Opts.SanitizeCoveragePCTable = Args.hasArg(OPT_fsanitize_coverage_pc_table);
+   Opts.SanitizeCoverageStackDepth =
+       Args.hasArg(OPT_fsanitize_coverage_stack_depth);
+   Opts.SanitizeMemoryTrackOrigins =
+       getLastArgIntValue(Args, OPT_fsanitize_memory_track_origins_EQ, 0, Diags);
+   Opts.SanitizeMemoryUseAfterDtor =
+       Args.hasFlag(OPT_fsanitize_memory_use_after_dtor,
+                    OPT_fno_sanitize_memory_use_after_dtor,
+                    false);
+   Opts.SanitizeMinimalRuntime = Args.hasArg(OPT_fsanitize_minimal_runtime);
+   Opts.SanitizeCfiCrossDso = Args.hasArg(OPT_fsanitize_cfi_cross_dso);
+   Opts.SanitizeCfiICallGeneralizePointers =
+       Args.hasArg(OPT_fsanitize_cfi_icall_generalize_pointers);
+   Opts.SanitizeStats = Args.hasArg(OPT_fsanitize_stats);
+   if (Arg *A = Args.getLastArg(
+           OPT_fsanitize_address_poison_class_member_array_new_cookie,
+           OPT_fno_sanitize_address_poison_class_member_array_new_cookie)) {
+     Opts.SanitizeAddressPoisonClassMemberArrayNewCookie =
+         A->getOption().getID() ==
+         OPT_fsanitize_address_poison_class_member_array_new_cookie;
+   }
+   if (Arg *A = Args.getLastArg(OPT_fsanitize_address_use_after_scope,
+                                OPT_fno_sanitize_address_use_after_scope)) {
+     Opts.SanitizeAddressUseAfterScope =
+         A->getOption().getID() == OPT_fsanitize_address_use_after_scope;
+   }
+   Opts.SanitizeAddressGlobalsDeadStripping =
+       Args.hasArg(OPT_fsanitize_address_globals_dead_stripping);
+   Opts.SSPBufferSize =
+       getLastArgIntValue(Args, OPT_stack_protector_buffer_size, 8, Diags);
+   Opts.StackRealignment = Args.hasArg(OPT_mstackrealign);
+   if (Arg *A = Args.getLastArg(OPT_mstack_alignment)) {
+     StringRef Val = A->getValue();
+     unsigned StackAlignment = Opts.StackAlignment;
+     Val.getAsInteger(10, StackAlignment);
+     Opts.StackAlignment = StackAlignment;
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_mstack_probe_size)) {
+     StringRef Val = A->getValue();
+     unsigned StackProbeSize = Opts.StackProbeSize;
+     Val.getAsInteger(0, StackProbeSize);
+     Opts.StackProbeSize = StackProbeSize;
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_fobjc_dispatch_method_EQ)) {
+     StringRef Name = A->getValue();
+     unsigned Method = llvm::StringSwitch<unsigned>(Name)
+       .Case("legacy", CodeGenOptions::Legacy)
+       .Case("non-legacy", CodeGenOptions::NonLegacy)
+       .Case("mixed", CodeGenOptions::Mixed)
+       .Default(~0U);
+     if (Method == ~0U) {
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Name;
+       Success = false;
+     } else {
+       Opts.setObjCDispatchMethod(
+         static_cast<CodeGenOptions::ObjCDispatchMethodKind>(Method));
+     }
+   }
+ 
+   Opts.EmulatedTLS =
+       Args.hasFlag(OPT_femulated_tls, OPT_fno_emulated_tls, false);
+ 
+   if (Arg *A = Args.getLastArg(OPT_ftlsmodel_EQ)) {
+     StringRef Name = A->getValue();
+     unsigned Model = llvm::StringSwitch<unsigned>(Name)
+         .Case("global-dynamic", CodeGenOptions::GeneralDynamicTLSModel)
+         .Case("local-dynamic", CodeGenOptions::LocalDynamicTLSModel)
+         .Case("initial-exec", CodeGenOptions::InitialExecTLSModel)
+         .Case("local-exec", CodeGenOptions::LocalExecTLSModel)
+         .Default(~0U);
+     if (Model == ~0U) {
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Name;
+       Success = false;
+     } else {
+       Opts.setDefaultTLSModel(static_cast<CodeGenOptions::TLSModel>(Model));
+     }
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_fdenormal_fp_math_EQ)) {
+     StringRef Val = A->getValue();
+     if (Val == "ieee")
+       Opts.FPDenormalMode = "ieee";
+     else if (Val == "preserve-sign")
+       Opts.FPDenormalMode = "preserve-sign";
+     else if (Val == "positive-zero")
+       Opts.FPDenormalMode = "positive-zero";
+     else
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Val;
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_fpcc_struct_return, OPT_freg_struct_return)) {
+     if (A->getOption().matches(OPT_fpcc_struct_return)) {
+       Opts.setStructReturnConvention(CodeGenOptions::SRCK_OnStack);
+     } else {
+       assert(A->getOption().matches(OPT_freg_struct_return));
+       Opts.setStructReturnConvention(CodeGenOptions::SRCK_InRegs);
+     }
+   }
+ 
+   Opts.DependentLibraries = Args.getAllArgValues(OPT_dependent_lib);
+   Opts.LinkerOptions = Args.getAllArgValues(OPT_linker_option);
+   bool NeedLocTracking = false;
+ 
+   Opts.OptRecordFile = Args.getLastArgValue(OPT_opt_record_file);
+   if (!Opts.OptRecordFile.empty())
+     NeedLocTracking = true;
+ 
+   if (Arg *A = Args.getLastArg(OPT_Rpass_EQ)) {
+     Opts.OptimizationRemarkPattern =
+         GenerateOptimizationRemarkRegex(Diags, Args, A);
+     NeedLocTracking = true;
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_Rpass_missed_EQ)) {
+     Opts.OptimizationRemarkMissedPattern =
+         GenerateOptimizationRemarkRegex(Diags, Args, A);
+     NeedLocTracking = true;
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_Rpass_analysis_EQ)) {
+     Opts.OptimizationRemarkAnalysisPattern =
+         GenerateOptimizationRemarkRegex(Diags, Args, A);
+     NeedLocTracking = true;
+   }
+ 
+   Opts.DiagnosticsWithHotness =
+       Args.hasArg(options::OPT_fdiagnostics_show_hotness);
+   bool UsingSampleProfile = !Opts.SampleProfileFile.empty();
+   bool UsingProfile = UsingSampleProfile ||
+       (Opts.getProfileUse() != CodeGenOptions::ProfileNone);
+ 
+   if (Opts.DiagnosticsWithHotness && !UsingProfile)
+     Diags.Report(diag::warn_drv_diagnostics_hotness_requires_pgo)
+         << "-fdiagnostics-show-hotness";
+ 
+   Opts.DiagnosticsHotnessThreshold = getLastArgUInt64Value(
+       Args, options::OPT_fdiagnostics_hotness_threshold_EQ, 0);
+   if (Opts.DiagnosticsHotnessThreshold > 0 && !UsingProfile)
+     Diags.Report(diag::warn_drv_diagnostics_hotness_requires_pgo)
+         << "-fdiagnostics-hotness-threshold=";
+ 
+   // If the user requested to use a sample profile for PGO, then the
+   // backend will need to track source location information so the profile
+   // can be incorporated into the IR.
+   if (UsingSampleProfile)
+     NeedLocTracking = true;
+ 
+   // If the user requested a flag that requires source locations available in
+   // the backend, make sure that the backend tracks source location information.
+   if (NeedLocTracking && Opts.getDebugInfo() == codegenoptions::NoDebugInfo)
+     Opts.setDebugInfo(codegenoptions::LocTrackingOnly);
+ 
+   Opts.RewriteMapFiles = Args.getAllArgValues(OPT_frewrite_map_file);
+ 
+   // Parse -fsanitize-recover= arguments.
+   // FIXME: Report unrecoverable sanitizers incorrectly specified here.
+   parseSanitizerKinds("-fsanitize-recover=",
+                       Args.getAllArgValues(OPT_fsanitize_recover_EQ), Diags,
+                       Opts.SanitizeRecover);
+   parseSanitizerKinds("-fsanitize-trap=",
+                       Args.getAllArgValues(OPT_fsanitize_trap_EQ), Diags,
+                       Opts.SanitizeTrap);
+ 
+   Opts.CudaGpuBinaryFileNames =
+       Args.getAllArgValues(OPT_fcuda_include_gpubinary);
+ 
+   Opts.Backchain = Args.hasArg(OPT_mbackchain);
+ 
+   Opts.EmitCheckPathComponentsToStrip = getLastArgIntValue(
+       Args, OPT_fsanitize_undefined_strip_path_components_EQ, 0, Diags);
+ 
+   return Success;
+ }
+ 
+ static void ParseDependencyOutputArgs(DependencyOutputOptions &Opts,
+                                       ArgList &Args) {
+   using namespace options;
+   Opts.OutputFile = Args.getLastArgValue(OPT_dependency_file);
+   Opts.Targets = Args.getAllArgValues(OPT_MT);
+   Opts.IncludeSystemHeaders = Args.hasArg(OPT_sys_header_deps);
+   Opts.IncludeModuleFiles = Args.hasArg(OPT_module_file_deps);
+   Opts.UsePhonyTargets = Args.hasArg(OPT_MP);
+   Opts.ShowHeaderIncludes = Args.hasArg(OPT_H);
+   Opts.HeaderIncludeOutputFile = Args.getLastArgValue(OPT_header_include_file);
+   Opts.AddMissingHeaderDeps = Args.hasArg(OPT_MG);
+   Opts.PrintShowIncludes = Args.hasArg(OPT_show_includes);
+   Opts.DOTOutputFile = Args.getLastArgValue(OPT_dependency_dot);
+   Opts.ModuleDependencyOutputDir =
+       Args.getLastArgValue(OPT_module_dependency_dir);
+   if (Args.hasArg(OPT_MV))
+     Opts.OutputFormat = DependencyOutputFormat::NMake;
+   // Add sanitizer blacklists as extra dependencies.
+   // They won't be discovered by the regular preprocessor, so
+   // we let make / ninja to know about this implicit dependency.
+   Opts.ExtraDeps = Args.getAllArgValues(OPT_fdepfile_entry);
+   // Only the -fmodule-file=<file> form.
+   for (const Arg *A : Args.filtered(OPT_fmodule_file)) {
+     StringRef Val = A->getValue();
+     if (Val.find('=') == StringRef::npos)
+       Opts.ExtraDeps.push_back(Val);
+   }
+ }
+ 
+ static bool parseShowColorsArgs(const ArgList &Args, bool DefaultColor) {
+   // Color diagnostics default to auto ("on" if terminal supports) in the driver
+   // but default to off in cc1, needing an explicit OPT_fdiagnostics_color.
+   // Support both clang's -f[no-]color-diagnostics and gcc's
+   // -f[no-]diagnostics-colors[=never|always|auto].
+   enum {
+     Colors_On,
+     Colors_Off,
+     Colors_Auto
+   } ShowColors = DefaultColor ? Colors_Auto : Colors_Off;
+   for (Arg *A : Args) {
+     const Option &O = A->getOption();
+     if (O.matches(options::OPT_fcolor_diagnostics) ||
+         O.matches(options::OPT_fdiagnostics_color)) {
+       ShowColors = Colors_On;
+     } else if (O.matches(options::OPT_fno_color_diagnostics) ||
+                O.matches(options::OPT_fno_diagnostics_color)) {
+       ShowColors = Colors_Off;
+     } else if (O.matches(options::OPT_fdiagnostics_color_EQ)) {
+       StringRef Value(A->getValue());
+       if (Value == "always")
+         ShowColors = Colors_On;
+       else if (Value == "never")
+         ShowColors = Colors_Off;
+       else if (Value == "auto")
+         ShowColors = Colors_Auto;
+     }
+   }
+   return ShowColors == Colors_On ||
+          (ShowColors == Colors_Auto &&
+           llvm::sys::Process::StandardErrHasColors());
+ }
+ 
+ static bool checkVerifyPrefixes(const std::vector<std::string> &VerifyPrefixes,
+                                 DiagnosticsEngine *Diags) {
+   bool Success = true;
+   for (const auto &Prefix : VerifyPrefixes) {
+     // Every prefix must start with a letter and contain only alphanumeric
+     // characters, hyphens, and underscores.
+     auto BadChar = std::find_if(Prefix.begin(), Prefix.end(),
+                                 [](char C){return !isAlphanumeric(C)
+                                                   && C != '-' && C != '_';});
+     if (BadChar != Prefix.end() || !isLetter(Prefix[0])) {
+       Success = false;
+       if (Diags) {
+         Diags->Report(diag::err_drv_invalid_value) << "-verify=" << Prefix;
+         Diags->Report(diag::note_drv_verify_prefix_spelling);
+       }
+     }
+   }
+   return Success;
+ }
+ 
+ bool clang::ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
+                                 DiagnosticsEngine *Diags,
+                                 bool DefaultDiagColor, bool DefaultShowOpt) {
+   using namespace options;
+   bool Success = true;
+ 
+   Opts.DiagnosticLogFile = Args.getLastArgValue(OPT_diagnostic_log_file);
+   if (Arg *A =
+           Args.getLastArg(OPT_diagnostic_serialized_file, OPT__serialize_diags))
+     Opts.DiagnosticSerializationFile = A->getValue();
+   Opts.IgnoreWarnings = Args.hasArg(OPT_w);
+   Opts.NoRewriteMacros = Args.hasArg(OPT_Wno_rewrite_macros);
+   Opts.Pedantic = Args.hasArg(OPT_pedantic);
+   Opts.PedanticErrors = Args.hasArg(OPT_pedantic_errors);
+   Opts.ShowCarets = !Args.hasArg(OPT_fno_caret_diagnostics);
+   Opts.ShowColors = parseShowColorsArgs(Args, DefaultDiagColor);
+   Opts.ShowColumn = Args.hasFlag(OPT_fshow_column,
+                                  OPT_fno_show_column,
+                                  /*Default=*/true);
+   Opts.ShowFixits = !Args.hasArg(OPT_fno_diagnostics_fixit_info);
+   Opts.ShowLocation = !Args.hasArg(OPT_fno_show_source_location);
+   Opts.AbsolutePath = Args.hasArg(OPT_fdiagnostics_absolute_paths);
+   Opts.ShowOptionNames =
+       Args.hasFlag(OPT_fdiagnostics_show_option,
+                    OPT_fno_diagnostics_show_option, DefaultShowOpt);
+ 
+   llvm::sys::Process::UseANSIEscapeCodes(Args.hasArg(OPT_fansi_escape_codes));
+ 
+   // Default behavior is to not to show note include stacks.
+   Opts.ShowNoteIncludeStack = false;
+   if (Arg *A = Args.getLastArg(OPT_fdiagnostics_show_note_include_stack,
+                                OPT_fno_diagnostics_show_note_include_stack))
+     if (A->getOption().matches(OPT_fdiagnostics_show_note_include_stack))
+       Opts.ShowNoteIncludeStack = true;
+ 
+   StringRef ShowOverloads =
+     Args.getLastArgValue(OPT_fshow_overloads_EQ, "all");
+   if (ShowOverloads == "best")
+     Opts.setShowOverloads(Ovl_Best);
+   else if (ShowOverloads == "all")
+     Opts.setShowOverloads(Ovl_All);
+   else {
+     Success = false;
+     if (Diags)
+       Diags->Report(diag::err_drv_invalid_value)
+       << Args.getLastArg(OPT_fshow_overloads_EQ)->getAsString(Args)
+       << ShowOverloads;
+   }
+ 
+   StringRef ShowCategory =
+     Args.getLastArgValue(OPT_fdiagnostics_show_category, "none");
+   if (ShowCategory == "none")
+     Opts.ShowCategories = 0;
+   else if (ShowCategory == "id")
+     Opts.ShowCategories = 1;
+   else if (ShowCategory == "name")
+     Opts.ShowCategories = 2;
+   else {
+     Success = false;
+     if (Diags)
+       Diags->Report(diag::err_drv_invalid_value)
+       << Args.getLastArg(OPT_fdiagnostics_show_category)->getAsString(Args)
+       << ShowCategory;
+   }
+ 
+   StringRef Format =
+     Args.getLastArgValue(OPT_fdiagnostics_format, "clang");
+   if (Format == "clang")
+     Opts.setFormat(DiagnosticOptions::Clang);
+   else if (Format == "msvc")
+     Opts.setFormat(DiagnosticOptions::MSVC);
+   else if (Format == "msvc-fallback") {
+     Opts.setFormat(DiagnosticOptions::MSVC);
+     Opts.CLFallbackMode = true;
+   } else if (Format == "vi")
+     Opts.setFormat(DiagnosticOptions::Vi);
+   else {
+     Success = false;
+     if (Diags)
+       Diags->Report(diag::err_drv_invalid_value)
+       << Args.getLastArg(OPT_fdiagnostics_format)->getAsString(Args)
+       << Format;
+   }
+ 
+   Opts.ShowSourceRanges = Args.hasArg(OPT_fdiagnostics_print_source_range_info);
+   Opts.ShowParseableFixits = Args.hasArg(OPT_fdiagnostics_parseable_fixits);
+   Opts.ShowPresumedLoc = !Args.hasArg(OPT_fno_diagnostics_use_presumed_location);
+   Opts.VerifyDiagnostics = Args.hasArg(OPT_verify) || Args.hasArg(OPT_verify_EQ);
+   Opts.VerifyPrefixes = Args.getAllArgValues(OPT_verify_EQ);
+   if (Args.hasArg(OPT_verify))
+     Opts.VerifyPrefixes.push_back("expected");
+   // Keep VerifyPrefixes in its original order for the sake of diagnostics, and
+   // then sort it to prepare for fast lookup using std::binary_search.
+   if (!checkVerifyPrefixes(Opts.VerifyPrefixes, Diags)) {
+     Opts.VerifyDiagnostics = false;
+     Success = false;
+   }
+   else
+     std::sort(Opts.VerifyPrefixes.begin(), Opts.VerifyPrefixes.end());
+   DiagnosticLevelMask DiagMask = DiagnosticLevelMask::None;
+   Success &= parseDiagnosticLevelMask("-verify-ignore-unexpected=",
+     Args.getAllArgValues(OPT_verify_ignore_unexpected_EQ),
+     Diags, DiagMask);
+   if (Args.hasArg(OPT_verify_ignore_unexpected))
+     DiagMask = DiagnosticLevelMask::All;
+   Opts.setVerifyIgnoreUnexpected(DiagMask);
+   Opts.ElideType = !Args.hasArg(OPT_fno_elide_type);
+   Opts.ShowTemplateTree = Args.hasArg(OPT_fdiagnostics_show_template_tree);
+   Opts.ErrorLimit = getLastArgIntValue(Args, OPT_ferror_limit, 0, Diags);
+   Opts.MacroBacktraceLimit =
+       getLastArgIntValue(Args, OPT_fmacro_backtrace_limit,
+                          DiagnosticOptions::DefaultMacroBacktraceLimit, Diags);
+   Opts.TemplateBacktraceLimit = getLastArgIntValue(
+       Args, OPT_ftemplate_backtrace_limit,
+       DiagnosticOptions::DefaultTemplateBacktraceLimit, Diags);
+   Opts.ConstexprBacktraceLimit = getLastArgIntValue(
+       Args, OPT_fconstexpr_backtrace_limit,
+       DiagnosticOptions::DefaultConstexprBacktraceLimit, Diags);
+   Opts.SpellCheckingLimit = getLastArgIntValue(
+       Args, OPT_fspell_checking_limit,
+       DiagnosticOptions::DefaultSpellCheckingLimit, Diags);
+   Opts.SnippetLineLimit = getLastArgIntValue(
+       Args, OPT_fcaret_diagnostics_max_lines,
+       DiagnosticOptions::DefaultSnippetLineLimit, Diags);
+   Opts.TabStop = getLastArgIntValue(Args, OPT_ftabstop,
+                                     DiagnosticOptions::DefaultTabStop, Diags);
+   if (Opts.TabStop == 0 || Opts.TabStop > DiagnosticOptions::MaxTabStop) {
+     Opts.TabStop = DiagnosticOptions::DefaultTabStop;
+     if (Diags)
+       Diags->Report(diag::warn_ignoring_ftabstop_value)
+       << Opts.TabStop << DiagnosticOptions::DefaultTabStop;
+   }
+   Opts.MessageLength = getLastArgIntValue(Args, OPT_fmessage_length, 0, Diags);
+   addDiagnosticArgs(Args, OPT_W_Group, OPT_W_value_Group, Opts.Warnings);
+   addDiagnosticArgs(Args, OPT_R_Group, OPT_R_value_Group, Opts.Remarks);
+ 
+   return Success;
+ }
+ 
+ static void ParseFileSystemArgs(FileSystemOptions &Opts, ArgList &Args) {
+   Opts.WorkingDir = Args.getLastArgValue(OPT_working_directory);
+ }
+ 
+ /// Parse the argument to the -ftest-module-file-extension
+ /// command-line argument.
+ ///
+ /// \returns true on error, false on success.
+ static bool parseTestModuleFileExtensionArg(StringRef Arg,
+                                             std::string &BlockName,
+                                             unsigned &MajorVersion,
+                                             unsigned &MinorVersion,
+                                             bool &Hashed,
+                                             std::string &UserInfo) {
+   SmallVector<StringRef, 5> Args;
+   Arg.split(Args, ':', 5);
+   if (Args.size() < 5)
+     return true;
+ 
+   BlockName = Args[0];
+   if (Args[1].getAsInteger(10, MajorVersion)) return true;
+   if (Args[2].getAsInteger(10, MinorVersion)) return true;
+   if (Args[3].getAsInteger(2, Hashed)) return true;
+   if (Args.size() > 4)
+     UserInfo = Args[4];
+   return false;
+ }
+ 
+ static InputKind ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
+                                    DiagnosticsEngine &Diags,
+                                    bool &IsHeaderFile) {
+   using namespace options;
+   Opts.ProgramAction = frontend::ParseSyntaxOnly;
+   if (const Arg *A = Args.getLastArg(OPT_Action_Group)) {
+     switch (A->getOption().getID()) {
+     default:
+       llvm_unreachable("Invalid option in group!");
+     case OPT_ast_list:
+       Opts.ProgramAction = frontend::ASTDeclList; break;
+     case OPT_ast_dump:
+     case OPT_ast_dump_all:
+     case OPT_ast_dump_lookups:
+       Opts.ProgramAction = frontend::ASTDump; break;
+     case OPT_ast_print:
+       Opts.ProgramAction = frontend::ASTPrint; break;
+     case OPT_ast_view:
+       Opts.ProgramAction = frontend::ASTView; break;
+     case OPT_dump_raw_tokens:
+       Opts.ProgramAction = frontend::DumpRawTokens; break;
+     case OPT_dump_tokens:
+       Opts.ProgramAction = frontend::DumpTokens; break;
+     case OPT_S:
+       Opts.ProgramAction = frontend::EmitAssembly; break;
+     case OPT_emit_llvm_bc:
+       Opts.ProgramAction = frontend::EmitBC; break;
+     case OPT_emit_html:
+       Opts.ProgramAction = frontend::EmitHTML; break;
+     case OPT_emit_llvm:
+       Opts.ProgramAction = frontend::EmitLLVM; break;
+     case OPT_emit_llvm_only:
+       Opts.ProgramAction = frontend::EmitLLVMOnly; break;
+     case OPT_emit_codegen_only:
+       Opts.ProgramAction = frontend::EmitCodeGenOnly; break;
+     case OPT_emit_obj:
+       Opts.ProgramAction = frontend::EmitObj; break;
+     case OPT_fixit_EQ:
+       Opts.FixItSuffix = A->getValue();
+       // fall-through!
+     case OPT_fixit:
+       Opts.ProgramAction = frontend::FixIt; break;
+     case OPT_emit_module:
+       Opts.ProgramAction = frontend::GenerateModule; break;
+     case OPT_emit_module_interface:
+       Opts.ProgramAction = frontend::GenerateModuleInterface; break;
+     case OPT_emit_pch:
+       Opts.ProgramAction = frontend::GeneratePCH; break;
+     case OPT_emit_pth:
+       Opts.ProgramAction = frontend::GeneratePTH; break;
+     case OPT_init_only:
+       Opts.ProgramAction = frontend::InitOnly; break;
+     case OPT_fsyntax_only:
+       Opts.ProgramAction = frontend::ParseSyntaxOnly; break;
+     case OPT_module_file_info:
+       Opts.ProgramAction = frontend::ModuleFileInfo; break;
+     case OPT_verify_pch:
+       Opts.ProgramAction = frontend::VerifyPCH; break;
+     case OPT_print_decl_contexts:
+       Opts.ProgramAction = frontend::PrintDeclContext; break;
+     case OPT_print_preamble:
+       Opts.ProgramAction = frontend::PrintPreamble; break;
+     case OPT_E:
+       Opts.ProgramAction = frontend::PrintPreprocessedInput; break;
+     case OPT_templight_dump:
+       Opts.ProgramAction = frontend::TemplightDump; break;
+     case OPT_rewrite_macros:
+       Opts.ProgramAction = frontend::RewriteMacros; break;
+     case OPT_rewrite_objc:
+       Opts.ProgramAction = frontend::RewriteObjC; break;
+     case OPT_rewrite_test:
+       Opts.ProgramAction = frontend::RewriteTest; break;
+     case OPT_analyze:
+       Opts.ProgramAction = frontend::RunAnalysis; break;
+     case OPT_migrate:
+       Opts.ProgramAction = frontend::MigrateSource; break;
+     case OPT_Eonly:
+       Opts.ProgramAction = frontend::RunPreprocessorOnly; break;
+     }
+   }
+ 
+   if (const Arg* A = Args.getLastArg(OPT_plugin)) {
+     Opts.Plugins.emplace_back(A->getValue(0));
+     Opts.ProgramAction = frontend::PluginAction;
+     Opts.ActionName = A->getValue();
+   }
+   Opts.AddPluginActions = Args.getAllArgValues(OPT_add_plugin);
+   for (const Arg *AA : Args.filtered(OPT_plugin_arg))
+     Opts.PluginArgs[AA->getValue(0)].emplace_back(AA->getValue(1));
+ 
+   for (const std::string &Arg :
+          Args.getAllArgValues(OPT_ftest_module_file_extension_EQ)) {
+     std::string BlockName;
+     unsigned MajorVersion;
+     unsigned MinorVersion;
+     bool Hashed;
+     std::string UserInfo;
+     if (parseTestModuleFileExtensionArg(Arg, BlockName, MajorVersion,
+                                         MinorVersion, Hashed, UserInfo)) {
+       Diags.Report(diag::err_test_module_file_extension_format) << Arg;
+ 
+       continue;
+     }
+ 
+     // Add the testing module file extension.
+     Opts.ModuleFileExtensions.push_back(
+         std::make_shared<TestModuleFileExtension>(
+             BlockName, MajorVersion, MinorVersion, Hashed, UserInfo));
+   }
+ 
+   if (const Arg *A = Args.getLastArg(OPT_code_completion_at)) {
+     Opts.CodeCompletionAt =
+       ParsedSourceLocation::FromString(A->getValue());
+     if (Opts.CodeCompletionAt.FileName.empty())
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << A->getValue();
+   }
+   Opts.DisableFree = Args.hasArg(OPT_disable_free);
+ 
+   Opts.OutputFile = Args.getLastArgValue(OPT_o);
+   Opts.Plugins = Args.getAllArgValues(OPT_load);
+   Opts.RelocatablePCH = Args.hasArg(OPT_relocatable_pch);
+   Opts.ShowHelp = Args.hasArg(OPT_help);
+   Opts.ShowStats = Args.hasArg(OPT_print_stats);
+   Opts.ShowTimers = Args.hasArg(OPT_ftime_report);
+   Opts.ShowVersion = Args.hasArg(OPT_version);
+   Opts.ASTMergeFiles = Args.getAllArgValues(OPT_ast_merge);
+   Opts.LLVMArgs = Args.getAllArgValues(OPT_mllvm);
+   Opts.FixWhatYouCan = Args.hasArg(OPT_fix_what_you_can);
+   Opts.FixOnlyWarnings = Args.hasArg(OPT_fix_only_warnings);
+   Opts.FixAndRecompile = Args.hasArg(OPT_fixit_recompile);
+   Opts.FixToTemporaries = Args.hasArg(OPT_fixit_to_temp);
+   Opts.ASTDumpDecls = Args.hasArg(OPT_ast_dump);
+   Opts.ASTDumpAll = Args.hasArg(OPT_ast_dump_all);
+   Opts.ASTDumpFilter = Args.getLastArgValue(OPT_ast_dump_filter);
+   Opts.ASTDumpLookups = Args.hasArg(OPT_ast_dump_lookups);
+   Opts.UseGlobalModuleIndex = !Args.hasArg(OPT_fno_modules_global_index);
+   Opts.GenerateGlobalModuleIndex = Opts.UseGlobalModuleIndex;
+   Opts.ModuleMapFiles = Args.getAllArgValues(OPT_fmodule_map_file);
+   // Only the -fmodule-file=<file> form.
+   for (const Arg *A : Args.filtered(OPT_fmodule_file)) {
+     StringRef Val = A->getValue();
+     if (Val.find('=') == StringRef::npos)
+       Opts.ModuleFiles.push_back(Val);
+   }
+   Opts.ModulesEmbedFiles = Args.getAllArgValues(OPT_fmodules_embed_file_EQ);
+   Opts.ModulesEmbedAllFiles = Args.hasArg(OPT_fmodules_embed_all_files);
+   Opts.IncludeTimestamps = !Args.hasArg(OPT_fno_pch_timestamp);
++  Opts.TemplightProfile = Args.hasArg(OPT_templight_profile);
+ 
+   Opts.CodeCompleteOpts.IncludeMacros
+     = Args.hasArg(OPT_code_completion_macros);
+   Opts.CodeCompleteOpts.IncludeCodePatterns
+     = Args.hasArg(OPT_code_completion_patterns);
+   Opts.CodeCompleteOpts.IncludeGlobals
+     = !Args.hasArg(OPT_no_code_completion_globals);
+   Opts.CodeCompleteOpts.IncludeNamespaceLevelDecls
+     = !Args.hasArg(OPT_no_code_completion_ns_level_decls);
+   Opts.CodeCompleteOpts.IncludeBriefComments
+     = Args.hasArg(OPT_code_completion_brief_comments);
+ 
+   Opts.OverrideRecordLayoutsFile
+     = Args.getLastArgValue(OPT_foverride_record_layout_EQ);
+   Opts.AuxTriple =
+       llvm::Triple::normalize(Args.getLastArgValue(OPT_aux_triple));
+   Opts.FindPchSource = Args.getLastArgValue(OPT_find_pch_source_EQ);
+   Opts.StatsFile = Args.getLastArgValue(OPT_stats_file);
+ 
+   if (const Arg *A = Args.getLastArg(OPT_arcmt_check,
+                                      OPT_arcmt_modify,
+                                      OPT_arcmt_migrate)) {
+     switch (A->getOption().getID()) {
+     default:
+       llvm_unreachable("missed a case");
+     case OPT_arcmt_check:
+       Opts.ARCMTAction = FrontendOptions::ARCMT_Check;
+       break;
+     case OPT_arcmt_modify:
+       Opts.ARCMTAction = FrontendOptions::ARCMT_Modify;
+       break;
+     case OPT_arcmt_migrate:
+       Opts.ARCMTAction = FrontendOptions::ARCMT_Migrate;
+       break;
+     }
+   }
+   Opts.MTMigrateDir = Args.getLastArgValue(OPT_mt_migrate_directory);
+   Opts.ARCMTMigrateReportOut
+     = Args.getLastArgValue(OPT_arcmt_migrate_report_output);
+   Opts.ARCMTMigrateEmitARCErrors
+     = Args.hasArg(OPT_arcmt_migrate_emit_arc_errors);
+ 
+   if (Args.hasArg(OPT_objcmt_migrate_literals))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_Literals;
+   if (Args.hasArg(OPT_objcmt_migrate_subscripting))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_Subscripting;
+   if (Args.hasArg(OPT_objcmt_migrate_property_dot_syntax))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_PropertyDotSyntax;
+   if (Args.hasArg(OPT_objcmt_migrate_property))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_Property;
+   if (Args.hasArg(OPT_objcmt_migrate_readonly_property))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_ReadonlyProperty;
+   if (Args.hasArg(OPT_objcmt_migrate_readwrite_property))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_ReadwriteProperty;
+   if (Args.hasArg(OPT_objcmt_migrate_annotation))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_Annotation;
+   if (Args.hasArg(OPT_objcmt_returns_innerpointer_property))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_ReturnsInnerPointerProperty;
+   if (Args.hasArg(OPT_objcmt_migrate_instancetype))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_Instancetype;
+   if (Args.hasArg(OPT_objcmt_migrate_nsmacros))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_NsMacros;
+   if (Args.hasArg(OPT_objcmt_migrate_protocol_conformance))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_ProtocolConformance;
+   if (Args.hasArg(OPT_objcmt_atomic_property))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_AtomicProperty;
+   if (Args.hasArg(OPT_objcmt_ns_nonatomic_iosonly))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_NsAtomicIOSOnlyProperty;
+   if (Args.hasArg(OPT_objcmt_migrate_designated_init))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_DesignatedInitializer;
+   if (Args.hasArg(OPT_objcmt_migrate_all))
+     Opts.ObjCMTAction |= FrontendOptions::ObjCMT_MigrateDecls;
+ 
+   Opts.ObjCMTWhiteListPath = Args.getLastArgValue(OPT_objcmt_whitelist_dir_path);
+ 
+   if (Opts.ARCMTAction != FrontendOptions::ARCMT_None &&
+       Opts.ObjCMTAction != FrontendOptions::ObjCMT_None) {
+     Diags.Report(diag::err_drv_argument_not_allowed_with)
+       << "ARC migration" << "ObjC migration";
+   }
+ 
+   InputKind DashX(InputKind::Unknown);
+   if (const Arg *A = Args.getLastArg(OPT_x)) {
+     StringRef XValue = A->getValue();
+ 
+     // Parse suffixes: '<lang>(-header|[-module-map][-cpp-output])'.
+     // FIXME: Supporting '<lang>-header-cpp-output' would be useful.
+     bool Preprocessed = XValue.consume_back("-cpp-output");
+     bool ModuleMap = XValue.consume_back("-module-map");
+     IsHeaderFile =
+         !Preprocessed && !ModuleMap && XValue.consume_back("-header");
+ 
+     // Principal languages.
+     DashX = llvm::StringSwitch<InputKind>(XValue)
+                 .Case("c", InputKind::C)
+                 .Case("cl", InputKind::OpenCL)
+                 .Case("cuda", InputKind::CUDA)
+                 .Case("c++", InputKind::CXX)
+                 .Case("objective-c", InputKind::ObjC)
+                 .Case("objective-c++", InputKind::ObjCXX)
+                 .Case("renderscript", InputKind::RenderScript)
+                 .Default(InputKind::Unknown);
+ 
+     // "objc[++]-cpp-output" is an acceptable synonym for
+     // "objective-c[++]-cpp-output".
+     if (DashX.isUnknown() && Preprocessed && !IsHeaderFile && !ModuleMap)
+       DashX = llvm::StringSwitch<InputKind>(XValue)
+                   .Case("objc", InputKind::ObjC)
+                   .Case("objc++", InputKind::ObjCXX)
+                   .Default(InputKind::Unknown);
+ 
+     // Some special cases cannot be combined with suffixes.
+     if (DashX.isUnknown() && !Preprocessed && !ModuleMap && !IsHeaderFile)
+       DashX = llvm::StringSwitch<InputKind>(XValue)
+                   .Case("cpp-output", InputKind(InputKind::C).getPreprocessed())
+                   .Case("assembler-with-cpp", InputKind::Asm)
+                   .Cases("ast", "pcm",
+                          InputKind(InputKind::Unknown, InputKind::Precompiled))
+                   .Case("ir", InputKind::LLVM_IR)
+                   .Default(InputKind::Unknown);
+ 
+     if (DashX.isUnknown())
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << A->getValue();
+ 
+     if (Preprocessed)
+       DashX = DashX.getPreprocessed();
+     if (ModuleMap)
+       DashX = DashX.withFormat(InputKind::ModuleMap);
+   }
+ 
+   // '-' is the default input if none is given.
+   std::vector<std::string> Inputs = Args.getAllArgValues(OPT_INPUT);
+   Opts.Inputs.clear();
+   if (Inputs.empty())
+     Inputs.push_back("-");
+   for (unsigned i = 0, e = Inputs.size(); i != e; ++i) {
+     InputKind IK = DashX;
+     if (IK.isUnknown()) {
+       IK = FrontendOptions::getInputKindForExtension(
+         StringRef(Inputs[i]).rsplit('.').second);
+       // FIXME: Warn on this?
+       if (IK.isUnknown())
+         IK = InputKind::C;
+       // FIXME: Remove this hack.
+       if (i == 0)
+         DashX = IK;
+     }
+ 
+     // The -emit-module action implicitly takes a module map.
+     if (Opts.ProgramAction == frontend::GenerateModule &&
+         IK.getFormat() == InputKind::Source)
+       IK = IK.withFormat(InputKind::ModuleMap);
+ 
+     Opts.Inputs.emplace_back(std::move(Inputs[i]), IK);
+   }
+ 
+   return DashX;
+ }
+ 
+ std::string CompilerInvocation::GetResourcesPath(const char *Argv0,
+                                                  void *MainAddr) {
+   std::string ClangExecutable =
+       llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
+   StringRef Dir = llvm::sys::path::parent_path(ClangExecutable);
+ 
+   // Compute the path to the resource directory.
+   StringRef ClangResourceDir(CLANG_RESOURCE_DIR);
+   SmallString<128> P(Dir);
+   if (ClangResourceDir != "")
+     llvm::sys::path::append(P, ClangResourceDir);
+   else
+     llvm::sys::path::append(P, "..", Twine("lib") + CLANG_LIBDIR_SUFFIX,
+                             "clang", CLANG_VERSION_STRING);
+ 
+   return P.str();
+ }
+ 
+ static void ParseHeaderSearchArgs(HeaderSearchOptions &Opts, ArgList &Args,
+                                   const std::string &WorkingDir) {
+   using namespace options;
+   Opts.Sysroot = Args.getLastArgValue(OPT_isysroot, "/");
+   Opts.Verbose = Args.hasArg(OPT_v);
+   Opts.UseBuiltinIncludes = !Args.hasArg(OPT_nobuiltininc);
+   Opts.UseStandardSystemIncludes = !Args.hasArg(OPT_nostdsysteminc);
+   Opts.UseStandardCXXIncludes = !Args.hasArg(OPT_nostdincxx);
+   if (const Arg *A = Args.getLastArg(OPT_stdlib_EQ))
+     Opts.UseLibcxx = (strcmp(A->getValue(), "libc++") == 0);
+   Opts.ResourceDir = Args.getLastArgValue(OPT_resource_dir);
+ 
+   // Canonicalize -fmodules-cache-path before storing it.
+   SmallString<128> P(Args.getLastArgValue(OPT_fmodules_cache_path));
+   if (!(P.empty() || llvm::sys::path::is_absolute(P))) {
+     if (WorkingDir.empty())
+       llvm::sys::fs::make_absolute(P);
+     else
+       llvm::sys::fs::make_absolute(WorkingDir, P);
+   }
+   llvm::sys::path::remove_dots(P);
+   Opts.ModuleCachePath = P.str();
+ 
+   Opts.ModuleUserBuildPath = Args.getLastArgValue(OPT_fmodules_user_build_path);
+   // Only the -fmodule-file=<name>=<file> form.
+   for (const Arg *A : Args.filtered(OPT_fmodule_file)) {
+     StringRef Val = A->getValue();
+     if (Val.find('=') != StringRef::npos)
+       Opts.PrebuiltModuleFiles.insert(Val.split('='));
+   }
+   for (const Arg *A : Args.filtered(OPT_fprebuilt_module_path))
+     Opts.AddPrebuiltModulePath(A->getValue());
+   Opts.DisableModuleHash = Args.hasArg(OPT_fdisable_module_hash);
+   Opts.ModulesHashContent = Args.hasArg(OPT_fmodules_hash_content);
+   Opts.ModulesValidateDiagnosticOptions =
+       !Args.hasArg(OPT_fmodules_disable_diagnostic_validation);
+   Opts.ImplicitModuleMaps = Args.hasArg(OPT_fimplicit_module_maps);
+   Opts.ModuleMapFileHomeIsCwd = Args.hasArg(OPT_fmodule_map_file_home_is_cwd);
+   Opts.ModuleCachePruneInterval =
+       getLastArgIntValue(Args, OPT_fmodules_prune_interval, 7 * 24 * 60 * 60);
+   Opts.ModuleCachePruneAfter =
+       getLastArgIntValue(Args, OPT_fmodules_prune_after, 31 * 24 * 60 * 60);
+   Opts.ModulesValidateOncePerBuildSession =
+       Args.hasArg(OPT_fmodules_validate_once_per_build_session);
+   Opts.BuildSessionTimestamp =
+       getLastArgUInt64Value(Args, OPT_fbuild_session_timestamp, 0);
+   Opts.ModulesValidateSystemHeaders =
+       Args.hasArg(OPT_fmodules_validate_system_headers);
+   if (const Arg *A = Args.getLastArg(OPT_fmodule_format_EQ))
+     Opts.ModuleFormat = A->getValue();
+ 
+   for (const Arg *A : Args.filtered(OPT_fmodules_ignore_macro)) {
+     StringRef MacroDef = A->getValue();
+     Opts.ModulesIgnoreMacros.insert(
+         llvm::CachedHashString(MacroDef.split('=').first));
+   }
+ 
+   // Add -I..., -F..., and -index-header-map options in order.
+   bool IsIndexHeaderMap = false;
+   bool IsSysrootSpecified =
+       Args.hasArg(OPT__sysroot_EQ) || Args.hasArg(OPT_isysroot);
+   for (const Arg *A : Args.filtered(OPT_I, OPT_F, OPT_index_header_map)) {
+     if (A->getOption().matches(OPT_index_header_map)) {
+       // -index-header-map applies to the next -I or -F.
+       IsIndexHeaderMap = true;
+       continue;
+     }
+ 
+     frontend::IncludeDirGroup Group =
+         IsIndexHeaderMap ? frontend::IndexHeaderMap : frontend::Angled;
+ 
+     bool IsFramework = A->getOption().matches(OPT_F);
+     std::string Path = A->getValue();
+ 
+     if (IsSysrootSpecified && !IsFramework && A->getValue()[0] == '=') {
+       SmallString<32> Buffer;
+       llvm::sys::path::append(Buffer, Opts.Sysroot,
+                               llvm::StringRef(A->getValue()).substr(1));
+       Path = Buffer.str();
+     }
+ 
+     Opts.AddPath(Path, Group, IsFramework,
+                  /*IgnoreSysroot*/ true);
+     IsIndexHeaderMap = false;
+   }
+ 
+   // Add -iprefix/-iwithprefix/-iwithprefixbefore options.
+   StringRef Prefix = ""; // FIXME: This isn't the correct default prefix.
+   for (const Arg *A :
+        Args.filtered(OPT_iprefix, OPT_iwithprefix, OPT_iwithprefixbefore)) {
+     if (A->getOption().matches(OPT_iprefix))
+       Prefix = A->getValue();
+     else if (A->getOption().matches(OPT_iwithprefix))
+       Opts.AddPath(Prefix.str() + A->getValue(), frontend::After, false, true);
+     else
+       Opts.AddPath(Prefix.str() + A->getValue(), frontend::Angled, false, true);
+   }
+ 
+   for (const Arg *A : Args.filtered(OPT_idirafter))
+     Opts.AddPath(A->getValue(), frontend::After, false, true);
+   for (const Arg *A : Args.filtered(OPT_iquote))
+     Opts.AddPath(A->getValue(), frontend::Quoted, false, true);
+   for (const Arg *A : Args.filtered(OPT_isystem, OPT_iwithsysroot))
+     Opts.AddPath(A->getValue(), frontend::System, false,
+                  !A->getOption().matches(OPT_iwithsysroot));
+   for (const Arg *A : Args.filtered(OPT_iframework))
+     Opts.AddPath(A->getValue(), frontend::System, true, true);
+   for (const Arg *A : Args.filtered(OPT_iframeworkwithsysroot))
+     Opts.AddPath(A->getValue(), frontend::System, /*IsFramework=*/true,
+                  /*IgnoreSysRoot=*/false);
+ 
+   // Add the paths for the various language specific isystem flags.
+   for (const Arg *A : Args.filtered(OPT_c_isystem))
+     Opts.AddPath(A->getValue(), frontend::CSystem, false, true);
+   for (const Arg *A : Args.filtered(OPT_cxx_isystem))
+     Opts.AddPath(A->getValue(), frontend::CXXSystem, false, true);
+   for (const Arg *A : Args.filtered(OPT_objc_isystem))
+     Opts.AddPath(A->getValue(), frontend::ObjCSystem, false,true);
+   for (const Arg *A : Args.filtered(OPT_objcxx_isystem))
+     Opts.AddPath(A->getValue(), frontend::ObjCXXSystem, false, true);
+ 
+   // Add the internal paths from a driver that detects standard include paths.
+   for (const Arg *A :
+        Args.filtered(OPT_internal_isystem, OPT_internal_externc_isystem)) {
+     frontend::IncludeDirGroup Group = frontend::System;
+     if (A->getOption().matches(OPT_internal_externc_isystem))
+       Group = frontend::ExternCSystem;
+     Opts.AddPath(A->getValue(), Group, false, true);
+   }
+ 
+   // Add the path prefixes which are implicitly treated as being system headers.
+   for (const Arg *A :
+        Args.filtered(OPT_system_header_prefix, OPT_no_system_header_prefix))
+     Opts.AddSystemHeaderPrefix(
+         A->getValue(), A->getOption().matches(OPT_system_header_prefix));
+ 
+   for (const Arg *A : Args.filtered(OPT_ivfsoverlay))
+     Opts.AddVFSOverlayFile(A->getValue());
+ }
+ 
+ void CompilerInvocation::setLangDefaults(LangOptions &Opts, InputKind IK,
+                                          const llvm::Triple &T,
+                                          PreprocessorOptions &PPOpts,
+                                          LangStandard::Kind LangStd) {
+   // Set some properties which depend solely on the input kind; it would be nice
+   // to move these to the language standard, and have the driver resolve the
+   // input kind + language standard.
+   //
+   // FIXME: Perhaps a better model would be for a single source file to have
+   // multiple language standards (C / C++ std, ObjC std, OpenCL std, OpenMP std)
+   // simultaneously active?
+   if (IK.getLanguage() == InputKind::Asm) {
+     Opts.AsmPreprocessor = 1;
+   } else if (IK.isObjectiveC()) {
+     Opts.ObjC1 = Opts.ObjC2 = 1;
+   }
+ 
+   if (LangStd == LangStandard::lang_unspecified) {
+     // Based on the base language, pick one.
+     switch (IK.getLanguage()) {
+     case InputKind::Unknown:
+     case InputKind::LLVM_IR:
+       llvm_unreachable("Invalid input kind!");
+     case InputKind::OpenCL:
+       LangStd = LangStandard::lang_opencl10;
+       break;
+     case InputKind::CUDA:
+       LangStd = LangStandard::lang_cuda;
+       break;
+     case InputKind::Asm:
+     case InputKind::C:
+       // The PS4 uses C99 as the default C standard.
+       if (T.isPS4())
+         LangStd = LangStandard::lang_gnu99;
+       else
+         LangStd = LangStandard::lang_gnu11;
+       break;
+     case InputKind::ObjC:
+       LangStd = LangStandard::lang_gnu11;
+       break;
+     case InputKind::CXX:
+     case InputKind::ObjCXX:
+       LangStd = LangStandard::lang_gnucxx14;
+       break;
+     case InputKind::RenderScript:
+       LangStd = LangStandard::lang_c99;
+       break;
+     }
+   }
+ 
+   const LangStandard &Std = LangStandard::getLangStandardForKind(LangStd);
+   Opts.LineComment = Std.hasLineComments();
+   Opts.C99 = Std.isC99();
+   Opts.C11 = Std.isC11();
+   Opts.C17 = Std.isC17();
+   Opts.CPlusPlus = Std.isCPlusPlus();
+   Opts.CPlusPlus11 = Std.isCPlusPlus11();
+   Opts.CPlusPlus14 = Std.isCPlusPlus14();
+   Opts.CPlusPlus17 = Std.isCPlusPlus17();
+   Opts.CPlusPlus2a = Std.isCPlusPlus2a();
+   Opts.Digraphs = Std.hasDigraphs();
+   Opts.GNUMode = Std.isGNUMode();
+   Opts.GNUInline = !Opts.C99 && !Opts.CPlusPlus;
+   Opts.HexFloats = Std.hasHexFloats();
+   Opts.ImplicitInt = Std.hasImplicitInt();
+ 
+   // Set OpenCL Version.
+   Opts.OpenCL = Std.isOpenCL();
+   if (LangStd == LangStandard::lang_opencl10)
+     Opts.OpenCLVersion = 100;
+   else if (LangStd == LangStandard::lang_opencl11)
+     Opts.OpenCLVersion = 110;
+   else if (LangStd == LangStandard::lang_opencl12)
+     Opts.OpenCLVersion = 120;
+   else if (LangStd == LangStandard::lang_opencl20)
+     Opts.OpenCLVersion = 200;
+ 
+   // OpenCL has some additional defaults.
+   if (Opts.OpenCL) {
+     Opts.AltiVec = 0;
+     Opts.ZVector = 0;
+     Opts.LaxVectorConversions = 0;
+     Opts.setDefaultFPContractMode(LangOptions::FPC_On);
+     Opts.NativeHalfType = 1;
+     Opts.NativeHalfArgsAndReturns = 1;
+     // Include default header file for OpenCL.
+     if (Opts.IncludeDefaultHeader) {
+       PPOpts.Includes.push_back("opencl-c.h");
+     }
+   }
+ 
+   Opts.CUDA = IK.getLanguage() == InputKind::CUDA;
+   if (Opts.CUDA)
+     // Set default FP_CONTRACT to FAST.
+     Opts.setDefaultFPContractMode(LangOptions::FPC_Fast);
+ 
+   Opts.RenderScript = IK.getLanguage() == InputKind::RenderScript;
+   if (Opts.RenderScript) {
+     Opts.NativeHalfType = 1;
+     Opts.NativeHalfArgsAndReturns = 1;
+   }
+ 
+   // OpenCL and C++ both have bool, true, false keywords.
+   Opts.Bool = Opts.OpenCL || Opts.CPlusPlus;
+ 
+   // OpenCL has half keyword
+   Opts.Half = Opts.OpenCL;
+ 
+   // C++ has wchar_t keyword.
+   Opts.WChar = Opts.CPlusPlus;
+ 
+   Opts.GNUKeywords = Opts.GNUMode;
+   Opts.CXXOperatorNames = Opts.CPlusPlus;
+ 
+   Opts.AlignedAllocation = Opts.CPlusPlus17;
+ 
+   Opts.DollarIdents = !Opts.AsmPreprocessor;
+ }
+ 
+ /// Attempt to parse a visibility value out of the given argument.
+ static Visibility parseVisibility(Arg *arg, ArgList &args,
+                                   DiagnosticsEngine &diags) {
+   StringRef value = arg->getValue();
+   if (value == "default") {
+     return DefaultVisibility;
+   } else if (value == "hidden" || value == "internal") {
+     return HiddenVisibility;
+   } else if (value == "protected") {
+     // FIXME: diagnose if target does not support protected visibility
+     return ProtectedVisibility;
+   }
+ 
+   diags.Report(diag::err_drv_invalid_value)
+     << arg->getAsString(args) << value;
+   return DefaultVisibility;
+ }
+ 
+ /// Check if input file kind and language standard are compatible.
+ static bool IsInputCompatibleWithStandard(InputKind IK,
+                                           const LangStandard &S) {
+   switch (IK.getLanguage()) {
+   case InputKind::Unknown:
+   case InputKind::LLVM_IR:
+     llvm_unreachable("should not parse language flags for this input");
+ 
+   case InputKind::C:
+   case InputKind::ObjC:
+   case InputKind::RenderScript:
+     return S.getLanguage() == InputKind::C;
+ 
+   case InputKind::OpenCL:
+     return S.getLanguage() == InputKind::OpenCL;
+ 
+   case InputKind::CXX:
+   case InputKind::ObjCXX:
+     return S.getLanguage() == InputKind::CXX;
+ 
+   case InputKind::CUDA:
+     // FIXME: What -std= values should be permitted for CUDA compilations?
+     return S.getLanguage() == InputKind::CUDA ||
+            S.getLanguage() == InputKind::CXX;
+ 
+   case InputKind::Asm:
+     // Accept (and ignore) all -std= values.
+     // FIXME: The -std= value is not ignored; it affects the tokenization
+     // and preprocessing rules if we're preprocessing this asm input.
+     return true;
+   }
+ 
+   llvm_unreachable("unexpected input language");
+ }
+ 
+ /// Get language name for given input kind.
+ static const StringRef GetInputKindName(InputKind IK) {
+   switch (IK.getLanguage()) {
+   case InputKind::C:
+     return "C";
+   case InputKind::ObjC:
+     return "Objective-C";
+   case InputKind::CXX:
+     return "C++";
+   case InputKind::ObjCXX:
+     return "Objective-C++";
+   case InputKind::OpenCL:
+     return "OpenCL";
+   case InputKind::CUDA:
+     return "CUDA";
+   case InputKind::RenderScript:
+     return "RenderScript";
+ 
+   case InputKind::Asm:
+     return "Asm";
+   case InputKind::LLVM_IR:
+     return "LLVM IR";
+ 
+   case InputKind::Unknown:
+     break;
+   }
+   llvm_unreachable("unknown input language");
+ }
+ 
+ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
+                           const TargetOptions &TargetOpts,
+                           PreprocessorOptions &PPOpts,
+                           DiagnosticsEngine &Diags) {
+   // FIXME: Cleanup per-file based stuff.
+   LangStandard::Kind LangStd = LangStandard::lang_unspecified;
+   if (const Arg *A = Args.getLastArg(OPT_std_EQ)) {
+     LangStd = llvm::StringSwitch<LangStandard::Kind>(A->getValue())
+ #define LANGSTANDARD(id, name, lang, desc, features) \
+       .Case(name, LangStandard::lang_##id)
+ #define LANGSTANDARD_ALIAS(id, alias) \
+       .Case(alias, LangStandard::lang_##id)
+ #include "clang/Frontend/LangStandards.def"
+       .Default(LangStandard::lang_unspecified);
+     if (LangStd == LangStandard::lang_unspecified) {
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << A->getValue();
+       // Report supported standards with short description.
+       for (unsigned KindValue = 0;
+            KindValue != LangStandard::lang_unspecified;
+            ++KindValue) {
+         const LangStandard &Std = LangStandard::getLangStandardForKind(
+           static_cast<LangStandard::Kind>(KindValue));
+         if (IsInputCompatibleWithStandard(IK, Std)) {
+           auto Diag = Diags.Report(diag::note_drv_use_standard);
+           Diag << Std.getName() << Std.getDescription();
+           unsigned NumAliases = 0;
+ #define LANGSTANDARD(id, name, lang, desc, features)
+ #define LANGSTANDARD_ALIAS(id, alias) \
+           if (KindValue == LangStandard::lang_##id) ++NumAliases;
+ #define LANGSTANDARD_ALIAS_DEPR(id, alias)
+ #include "clang/Frontend/LangStandards.def"
+           Diag << NumAliases;
+ #define LANGSTANDARD(id, name, lang, desc, features)
+ #define LANGSTANDARD_ALIAS(id, alias) \
+           if (KindValue == LangStandard::lang_##id) Diag << alias;
+ #define LANGSTANDARD_ALIAS_DEPR(id, alias)
+ #include "clang/Frontend/LangStandards.def"
+         }
+       }
+     } else {
+       // Valid standard, check to make sure language and standard are
+       // compatible.
+       const LangStandard &Std = LangStandard::getLangStandardForKind(LangStd);
+       if (!IsInputCompatibleWithStandard(IK, Std)) {
+         Diags.Report(diag::err_drv_argument_not_allowed_with)
+           << A->getAsString(Args) << GetInputKindName(IK);
+       }
+     }
+   }
+ 
+   // -cl-std only applies for OpenCL language standards.
+   // Override the -std option in this case.
+   if (const Arg *A = Args.getLastArg(OPT_cl_std_EQ)) {
+     LangStandard::Kind OpenCLLangStd
+       = llvm::StringSwitch<LangStandard::Kind>(A->getValue())
+         .Cases("cl", "CL", LangStandard::lang_opencl10)
+         .Cases("cl1.1", "CL1.1", LangStandard::lang_opencl11)
+         .Cases("cl1.2", "CL1.2", LangStandard::lang_opencl12)
+         .Cases("cl2.0", "CL2.0", LangStandard::lang_opencl20)
+         .Default(LangStandard::lang_unspecified);
+ 
+     if (OpenCLLangStd == LangStandard::lang_unspecified) {
+       Diags.Report(diag::err_drv_invalid_value)
+         << A->getAsString(Args) << A->getValue();
+     }
+     else
+       LangStd = OpenCLLangStd;
+   }
+ 
+   Opts.IncludeDefaultHeader = Args.hasArg(OPT_finclude_default_header);
+ 
+   llvm::Triple T(TargetOpts.Triple);
+   CompilerInvocation::setLangDefaults(Opts, IK, T, PPOpts, LangStd);
+ 
+   // -cl-strict-aliasing needs to emit diagnostic in the case where CL > 1.0.
+   // This option should be deprecated for CL > 1.0 because
+   // this option was added for compatibility with OpenCL 1.0.
+   if (Args.getLastArg(OPT_cl_strict_aliasing)
+        && Opts.OpenCLVersion > 100) {
+     std::string VerSpec = llvm::to_string(Opts.OpenCLVersion / 100) +
+                           std::string(".") +
+                           llvm::to_string((Opts.OpenCLVersion % 100) / 10);
+     Diags.Report(diag::warn_option_invalid_ocl_version)
+       << VerSpec << Args.getLastArg(OPT_cl_strict_aliasing)->getAsString(Args);
+   }
+ 
+   // We abuse '-f[no-]gnu-keywords' to force overriding all GNU-extension
+   // keywords. This behavior is provided by GCC's poorly named '-fasm' flag,
+   // while a subset (the non-C++ GNU keywords) is provided by GCC's
+   // '-fgnu-keywords'. Clang conflates the two for simplicity under the single
+   // name, as it doesn't seem a useful distinction.
+   Opts.GNUKeywords = Args.hasFlag(OPT_fgnu_keywords, OPT_fno_gnu_keywords,
+                                   Opts.GNUKeywords);
+ 
+   if (Args.hasArg(OPT_fno_operator_names))
+     Opts.CXXOperatorNames = 0;
+ 
+   if (Args.hasArg(OPT_fcuda_is_device))
+     Opts.CUDAIsDevice = 1;
+ 
+   if (Args.hasArg(OPT_fcuda_allow_variadic_functions))
+     Opts.CUDAAllowVariadicFunctions = 1;
+ 
+   if (Args.hasArg(OPT_fno_cuda_host_device_constexpr))
+     Opts.CUDAHostDeviceConstexpr = 0;
+ 
+   if (Opts.CUDAIsDevice && Args.hasArg(OPT_fcuda_flush_denormals_to_zero))
+     Opts.CUDADeviceFlushDenormalsToZero = 1;
+ 
+   if (Opts.CUDAIsDevice && Args.hasArg(OPT_fcuda_approx_transcendentals))
+     Opts.CUDADeviceApproxTranscendentals = 1;
+ 
+   Opts.CUDARelocatableDeviceCode = Args.hasArg(OPT_fcuda_rdc);
+ 
+   if (Opts.ObjC1) {
+     if (Arg *arg = Args.getLastArg(OPT_fobjc_runtime_EQ)) {
+       StringRef value = arg->getValue();
+       if (Opts.ObjCRuntime.tryParse(value))
+         Diags.Report(diag::err_drv_unknown_objc_runtime) << value;
+     }
+ 
+     if (Args.hasArg(OPT_fobjc_gc_only))
+       Opts.setGC(LangOptions::GCOnly);
+     else if (Args.hasArg(OPT_fobjc_gc))
+       Opts.setGC(LangOptions::HybridGC);
+     else if (Args.hasArg(OPT_fobjc_arc)) {
+       Opts.ObjCAutoRefCount = 1;
+       if (!Opts.ObjCRuntime.allowsARC())
+         Diags.Report(diag::err_arc_unsupported_on_runtime);
+     }
+ 
+     // ObjCWeakRuntime tracks whether the runtime supports __weak, not
+     // whether the feature is actually enabled.  This is predominantly
+     // determined by -fobjc-runtime, but we allow it to be overridden
+     // from the command line for testing purposes.
+     if (Args.hasArg(OPT_fobjc_runtime_has_weak))
+       Opts.ObjCWeakRuntime = 1;
+     else
+       Opts.ObjCWeakRuntime = Opts.ObjCRuntime.allowsWeak();
+ 
+     // ObjCWeak determines whether __weak is actually enabled.
+     // Note that we allow -fno-objc-weak to disable this even in ARC mode.
+     if (auto weakArg = Args.getLastArg(OPT_fobjc_weak, OPT_fno_objc_weak)) {
+       if (!weakArg->getOption().matches(OPT_fobjc_weak)) {
+         assert(!Opts.ObjCWeak);
+       } else if (Opts.getGC() != LangOptions::NonGC) {
+         Diags.Report(diag::err_objc_weak_with_gc);
+       } else if (!Opts.ObjCWeakRuntime) {
+         Diags.Report(diag::err_objc_weak_unsupported);
+       } else {
+         Opts.ObjCWeak = 1;
+       }
+     } else if (Opts.ObjCAutoRefCount) {
+       Opts.ObjCWeak = Opts.ObjCWeakRuntime;
+     }
+ 
+     if (Args.hasArg(OPT_fno_objc_infer_related_result_type))
+       Opts.ObjCInferRelatedResultType = 0;
+ 
+     if (Args.hasArg(OPT_fobjc_subscripting_legacy_runtime))
+       Opts.ObjCSubscriptingLegacyRuntime =
+         (Opts.ObjCRuntime.getKind() == ObjCRuntime::FragileMacOSX);
+   }
+ 
+   if (Args.hasArg(OPT_fgnu89_inline)) {
+     if (Opts.CPlusPlus)
+       Diags.Report(diag::err_drv_argument_not_allowed_with)
+         << "-fgnu89-inline" << GetInputKindName(IK);
+     else
+       Opts.GNUInline = 1;
+   }
+ 
+   if (Args.hasArg(OPT_fapple_kext)) {
+     if (!Opts.CPlusPlus)
+       Diags.Report(diag::warn_c_kext);
+     else
+       Opts.AppleKext = 1;
+   }
+ 
+   if (Args.hasArg(OPT_print_ivar_layout))
+     Opts.ObjCGCBitmapPrint = 1;
+   if (Args.hasArg(OPT_fno_constant_cfstrings))
+     Opts.NoConstantCFStrings = 1;
+ 
+   if (Args.hasArg(OPT_fzvector))
+     Opts.ZVector = 1;
+ 
+   if (Args.hasArg(OPT_pthread))
+     Opts.POSIXThreads = 1;
+ 
+   // The value-visibility mode defaults to "default".
+   if (Arg *visOpt = Args.getLastArg(OPT_fvisibility)) {
+     Opts.setValueVisibilityMode(parseVisibility(visOpt, Args, Diags));
+   } else {
+     Opts.setValueVisibilityMode(DefaultVisibility);
+   }
+ 
+   // The type-visibility mode defaults to the value-visibility mode.
+   if (Arg *typeVisOpt = Args.getLastArg(OPT_ftype_visibility)) {
+     Opts.setTypeVisibilityMode(parseVisibility(typeVisOpt, Args, Diags));
+   } else {
+     Opts.setTypeVisibilityMode(Opts.getValueVisibilityMode());
+   }
+ 
+   if (Args.hasArg(OPT_fvisibility_inlines_hidden))
+     Opts.InlineVisibilityHidden = 1;
+ 
+   if (Args.hasArg(OPT_ftrapv)) {
+     Opts.setSignedOverflowBehavior(LangOptions::SOB_Trapping);
+     // Set the handler, if one is specified.
+     Opts.OverflowHandler =
+         Args.getLastArgValue(OPT_ftrapv_handler);
+   }
+   else if (Args.hasArg(OPT_fwrapv))
+     Opts.setSignedOverflowBehavior(LangOptions::SOB_Defined);
+ 
+   Opts.MSVCCompat = Args.hasArg(OPT_fms_compatibility);
+   Opts.MicrosoftExt = Opts.MSVCCompat || Args.hasArg(OPT_fms_extensions);
+   Opts.AsmBlocks = Args.hasArg(OPT_fasm_blocks) || Opts.MicrosoftExt;
+   Opts.MSCompatibilityVersion = 0;
+   if (const Arg *A = Args.getLastArg(OPT_fms_compatibility_version)) {
+     VersionTuple VT;
+     if (VT.tryParse(A->getValue()))
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args)
+                                                 << A->getValue();
+     Opts.MSCompatibilityVersion = VT.getMajor() * 10000000 +
+                                   VT.getMinor().getValueOr(0) * 100000 +
+                                   VT.getSubminor().getValueOr(0);
+   }
+ 
+   // Mimicing gcc's behavior, trigraphs are only enabled if -trigraphs
+   // is specified, or -std is set to a conforming mode.
+   // Trigraphs are disabled by default in c++1z onwards.
+   Opts.Trigraphs = !Opts.GNUMode && !Opts.MSVCCompat && !Opts.CPlusPlus17;
+   Opts.Trigraphs =
+       Args.hasFlag(OPT_ftrigraphs, OPT_fno_trigraphs, Opts.Trigraphs);
+ 
+   Opts.DollarIdents = Args.hasFlag(OPT_fdollars_in_identifiers,
+                                    OPT_fno_dollars_in_identifiers,
+                                    Opts.DollarIdents);
+   Opts.PascalStrings = Args.hasArg(OPT_fpascal_strings);
+   Opts.VtorDispMode = getLastArgIntValue(Args, OPT_vtordisp_mode_EQ, 1, Diags);
+   Opts.Borland = Args.hasArg(OPT_fborland_extensions);
+   Opts.WritableStrings = Args.hasArg(OPT_fwritable_strings);
+   Opts.ConstStrings = Args.hasFlag(OPT_fconst_strings, OPT_fno_const_strings,
+                                    Opts.ConstStrings);
+   if (Args.hasArg(OPT_fno_lax_vector_conversions))
+     Opts.LaxVectorConversions = 0;
+   if (Args.hasArg(OPT_fno_threadsafe_statics))
+     Opts.ThreadsafeStatics = 0;
+   Opts.Exceptions = Args.hasArg(OPT_fexceptions);
+   Opts.ObjCExceptions = Args.hasArg(OPT_fobjc_exceptions);
+   Opts.CXXExceptions = Args.hasArg(OPT_fcxx_exceptions);
+ 
+   // Handle exception personalities
+   Arg *A = Args.getLastArg(options::OPT_fsjlj_exceptions,
+                            options::OPT_fseh_exceptions,
+                            options::OPT_fdwarf_exceptions);
+   if (A) {
+     const Option &Opt = A->getOption();
+     Opts.SjLjExceptions = Opt.matches(options::OPT_fsjlj_exceptions);
+     Opts.SEHExceptions = Opt.matches(options::OPT_fseh_exceptions);
+     Opts.DWARFExceptions = Opt.matches(options::OPT_fdwarf_exceptions);
+   }
+ 
+   Opts.ExternCNoUnwind = Args.hasArg(OPT_fexternc_nounwind);
+   Opts.TraditionalCPP = Args.hasArg(OPT_traditional_cpp);
+ 
+   Opts.RTTI = Opts.CPlusPlus && !Args.hasArg(OPT_fno_rtti);
+   Opts.RTTIData = Opts.RTTI && !Args.hasArg(OPT_fno_rtti_data);
+   Opts.Blocks = Args.hasArg(OPT_fblocks) || (Opts.OpenCL
+     && Opts.OpenCLVersion >= 200);
+   Opts.BlocksRuntimeOptional = Args.hasArg(OPT_fblocks_runtime_optional);
+   Opts.CoroutinesTS = Args.hasArg(OPT_fcoroutines_ts);
+ 
+   // Enable [[]] attributes in C++11 by default.
+   Opts.DoubleSquareBracketAttributes =
+       Args.hasFlag(OPT_fdouble_square_bracket_attributes,
+                    OPT_fno_double_square_bracket_attributes, Opts.CPlusPlus11);
+ 
+   Opts.ModulesTS = Args.hasArg(OPT_fmodules_ts);
+   Opts.Modules = Args.hasArg(OPT_fmodules) || Opts.ModulesTS;
+   Opts.ModulesStrictDeclUse = Args.hasArg(OPT_fmodules_strict_decluse);
+   Opts.ModulesDeclUse =
+       Args.hasArg(OPT_fmodules_decluse) || Opts.ModulesStrictDeclUse;
+   Opts.ModulesLocalVisibility =
+       Args.hasArg(OPT_fmodules_local_submodule_visibility) || Opts.ModulesTS;
+   Opts.ModulesCodegen = Args.hasArg(OPT_fmodules_codegen);
+   Opts.ModulesDebugInfo = Args.hasArg(OPT_fmodules_debuginfo);
+   Opts.ModulesSearchAll = Opts.Modules &&
+     !Args.hasArg(OPT_fno_modules_search_all) &&
+     Args.hasArg(OPT_fmodules_search_all);
+   Opts.ModulesErrorRecovery = !Args.hasArg(OPT_fno_modules_error_recovery);
+   Opts.ImplicitModules = !Args.hasArg(OPT_fno_implicit_modules);
+   Opts.CharIsSigned = Opts.OpenCL || !Args.hasArg(OPT_fno_signed_char);
+   Opts.WChar = Opts.CPlusPlus && !Args.hasArg(OPT_fno_wchar);
+   if (const Arg *A = Args.getLastArg(OPT_fwchar_type_EQ)) {
+     Opts.WCharSize = llvm::StringSwitch<unsigned>(A->getValue())
+                          .Case("char", 1)
+                          .Case("short", 2)
+                          .Case("int", 4)
+                          .Default(0);
+     if (Opts.WCharSize == 0)
+       Diags.Report(diag::err_fe_invalid_wchar_type) << A->getValue();
+   }
+   Opts.WCharIsSigned = Args.hasFlag(OPT_fsigned_wchar, OPT_fno_signed_wchar, true);
+   Opts.ShortEnums = Args.hasArg(OPT_fshort_enums);
+   Opts.Freestanding = Args.hasArg(OPT_ffreestanding);
+   Opts.NoBuiltin = Args.hasArg(OPT_fno_builtin) || Opts.Freestanding;
+   if (!Opts.NoBuiltin)
+     getAllNoBuiltinFuncValues(Args, Opts.NoBuiltinFuncs);
+   Opts.NoMathBuiltin = Args.hasArg(OPT_fno_math_builtin);
+   Opts.RelaxedTemplateTemplateArgs =
+       Args.hasArg(OPT_frelaxed_template_template_args);
+   Opts.SizedDeallocation = Args.hasArg(OPT_fsized_deallocation);
+   Opts.AlignedAllocation =
+       Args.hasFlag(OPT_faligned_allocation, OPT_fno_aligned_allocation,
+                    Opts.AlignedAllocation);
+   Opts.AlignedAllocationUnavailable =
+       Opts.AlignedAllocation && Args.hasArg(OPT_aligned_alloc_unavailable);
+   Opts.NewAlignOverride =
+       getLastArgIntValue(Args, OPT_fnew_alignment_EQ, 0, Diags);
+   if (Opts.NewAlignOverride && !llvm::isPowerOf2_32(Opts.NewAlignOverride)) {
+     Arg *A = Args.getLastArg(OPT_fnew_alignment_EQ);
+     Diags.Report(diag::err_fe_invalid_alignment) << A->getAsString(Args)
+                                                  << A->getValue();
+     Opts.NewAlignOverride = 0;
+   }
+   Opts.ConceptsTS = Args.hasArg(OPT_fconcepts_ts);
+   Opts.HeinousExtensions = Args.hasArg(OPT_fheinous_gnu_extensions);
+   Opts.AccessControl = !Args.hasArg(OPT_fno_access_control);
+   Opts.ElideConstructors = !Args.hasArg(OPT_fno_elide_constructors);
+   Opts.MathErrno = !Opts.OpenCL && Args.hasArg(OPT_fmath_errno);
+   Opts.InstantiationDepth =
+       getLastArgIntValue(Args, OPT_ftemplate_depth, 1024, Diags);
+   Opts.ArrowDepth =
+       getLastArgIntValue(Args, OPT_foperator_arrow_depth, 256, Diags);
+   Opts.ConstexprCallDepth =
+       getLastArgIntValue(Args, OPT_fconstexpr_depth, 512, Diags);
+   Opts.ConstexprStepLimit =
+       getLastArgIntValue(Args, OPT_fconstexpr_steps, 1048576, Diags);
+   Opts.BracketDepth = getLastArgIntValue(Args, OPT_fbracket_depth, 256, Diags);
+   Opts.DelayedTemplateParsing = Args.hasArg(OPT_fdelayed_template_parsing);
+   Opts.NumLargeByValueCopy =
+       getLastArgIntValue(Args, OPT_Wlarge_by_value_copy_EQ, 0, Diags);
+   Opts.MSBitfields = Args.hasArg(OPT_mms_bitfields);
+   Opts.ObjCConstantStringClass =
+     Args.getLastArgValue(OPT_fconstant_string_class);
+   Opts.ObjCDefaultSynthProperties =
+     !Args.hasArg(OPT_disable_objc_default_synthesize_properties);
+   Opts.EncodeExtendedBlockSig =
+     Args.hasArg(OPT_fencode_extended_block_signature);
+   Opts.EmitAllDecls = Args.hasArg(OPT_femit_all_decls);
+   Opts.PackStruct = getLastArgIntValue(Args, OPT_fpack_struct_EQ, 0, Diags);
+   Opts.MaxTypeAlign = getLastArgIntValue(Args, OPT_fmax_type_align_EQ, 0, Diags);
+   Opts.AlignDouble = Args.hasArg(OPT_malign_double);
+   Opts.PICLevel = getLastArgIntValue(Args, OPT_pic_level, 0, Diags);
+   Opts.PIE = Args.hasArg(OPT_pic_is_pie);
+   Opts.Static = Args.hasArg(OPT_static_define);
+   Opts.DumpRecordLayoutsSimple = Args.hasArg(OPT_fdump_record_layouts_simple);
+   Opts.DumpRecordLayouts = Opts.DumpRecordLayoutsSimple
+                         || Args.hasArg(OPT_fdump_record_layouts);
+   Opts.DumpVTableLayouts = Args.hasArg(OPT_fdump_vtable_layouts);
+   Opts.SpellChecking = !Args.hasArg(OPT_fno_spell_checking);
+   Opts.NoBitFieldTypeAlign = Args.hasArg(OPT_fno_bitfield_type_align);
+   Opts.SinglePrecisionConstants = Args.hasArg(OPT_cl_single_precision_constant);
+   Opts.FastRelaxedMath = Args.hasArg(OPT_cl_fast_relaxed_math);
+   Opts.HexagonQdsp6Compat = Args.hasArg(OPT_mqdsp6_compat);
+   Opts.FakeAddressSpaceMap = Args.hasArg(OPT_ffake_address_space_map);
+   Opts.ParseUnknownAnytype = Args.hasArg(OPT_funknown_anytype);
+   Opts.DebuggerSupport = Args.hasArg(OPT_fdebugger_support);
+   Opts.DebuggerCastResultToId = Args.hasArg(OPT_fdebugger_cast_result_to_id);
+   Opts.DebuggerObjCLiteral = Args.hasArg(OPT_fdebugger_objc_literal);
+   Opts.ApplePragmaPack = Args.hasArg(OPT_fapple_pragma_pack);
+   Opts.CurrentModule = Args.getLastArgValue(OPT_fmodule_name_EQ);
+   Opts.AppExt = Args.hasArg(OPT_fapplication_extension);
+   Opts.ModuleFeatures = Args.getAllArgValues(OPT_fmodule_feature);
+   std::sort(Opts.ModuleFeatures.begin(), Opts.ModuleFeatures.end());
+   Opts.NativeHalfType |= Args.hasArg(OPT_fnative_half_type);
+   Opts.NativeHalfArgsAndReturns |= Args.hasArg(OPT_fnative_half_arguments_and_returns);
+   // Enable HalfArgsAndReturns if present in Args or if NativeHalfArgsAndReturns
+   // is enabled.
+   Opts.HalfArgsAndReturns = Args.hasArg(OPT_fallow_half_arguments_and_returns)
+                             | Opts.NativeHalfArgsAndReturns;
+   Opts.GNUAsm = !Args.hasArg(OPT_fno_gnu_inline_asm);
+ 
+   // __declspec is enabled by default for the PS4 by the driver, and also
+   // enabled for Microsoft Extensions or Borland Extensions, here.
+   //
+   // FIXME: __declspec is also currently enabled for CUDA, but isn't really a
+   // CUDA extension. However, it is required for supporting
+   // __clang_cuda_builtin_vars.h, which uses __declspec(property). Once that has
+   // been rewritten in terms of something more generic, remove the Opts.CUDA
+   // term here.
+   Opts.DeclSpecKeyword =
+       Args.hasFlag(OPT_fdeclspec, OPT_fno_declspec,
+                    (Opts.MicrosoftExt || Opts.Borland || Opts.CUDA));
+ 
+   if (Arg *A = Args.getLastArg(OPT_faddress_space_map_mangling_EQ)) {
+     switch (llvm::StringSwitch<unsigned>(A->getValue())
+       .Case("target", LangOptions::ASMM_Target)
+       .Case("no", LangOptions::ASMM_Off)
+       .Case("yes", LangOptions::ASMM_On)
+       .Default(255)) {
+     default:
+       Diags.Report(diag::err_drv_invalid_value)
+         << "-faddress-space-map-mangling=" << A->getValue();
+       break;
+     case LangOptions::ASMM_Target:
+       Opts.setAddressSpaceMapMangling(LangOptions::ASMM_Target);
+       break;
+     case LangOptions::ASMM_On:
+       Opts.setAddressSpaceMapMangling(LangOptions::ASMM_On);
+       break;
+     case LangOptions::ASMM_Off:
+       Opts.setAddressSpaceMapMangling(LangOptions::ASMM_Off);
+       break;
+     }
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_fms_memptr_rep_EQ)) {
+     LangOptions::PragmaMSPointersToMembersKind InheritanceModel =
+         llvm::StringSwitch<LangOptions::PragmaMSPointersToMembersKind>(
+             A->getValue())
+             .Case("single",
+                   LangOptions::PPTMK_FullGeneralitySingleInheritance)
+             .Case("multiple",
+                   LangOptions::PPTMK_FullGeneralityMultipleInheritance)
+             .Case("virtual",
+                   LangOptions::PPTMK_FullGeneralityVirtualInheritance)
+             .Default(LangOptions::PPTMK_BestCase);
+     if (InheritanceModel == LangOptions::PPTMK_BestCase)
+       Diags.Report(diag::err_drv_invalid_value)
+           << "-fms-memptr-rep=" << A->getValue();
+ 
+     Opts.setMSPointerToMemberRepresentationMethod(InheritanceModel);
+   }
+ 
+   // Check for MS default calling conventions being specified.
+   if (Arg *A = Args.getLastArg(OPT_fdefault_calling_conv_EQ)) {
+     LangOptions::DefaultCallingConvention DefaultCC =
+         llvm::StringSwitch<LangOptions::DefaultCallingConvention>(A->getValue())
+             .Case("cdecl", LangOptions::DCC_CDecl)
+             .Case("fastcall", LangOptions::DCC_FastCall)
+             .Case("stdcall", LangOptions::DCC_StdCall)
+             .Case("vectorcall", LangOptions::DCC_VectorCall)
+             .Case("regcall", LangOptions::DCC_RegCall)
+             .Default(LangOptions::DCC_None);
+     if (DefaultCC == LangOptions::DCC_None)
+       Diags.Report(diag::err_drv_invalid_value)
+           << "-fdefault-calling-conv=" << A->getValue();
+ 
+     llvm::Triple T(TargetOpts.Triple);
+     llvm::Triple::ArchType Arch = T.getArch();
+     bool emitError = (DefaultCC == LangOptions::DCC_FastCall ||
+                       DefaultCC == LangOptions::DCC_StdCall) &&
+                      Arch != llvm::Triple::x86;
+     emitError |= (DefaultCC == LangOptions::DCC_VectorCall ||
+                   DefaultCC == LangOptions::DCC_RegCall) &&
+                  !(Arch == llvm::Triple::x86 || Arch == llvm::Triple::x86_64);
+     if (emitError)
+       Diags.Report(diag::err_drv_argument_not_allowed_with)
+           << A->getSpelling() << T.getTriple();
+     else
+       Opts.setDefaultCallingConv(DefaultCC);
+   }
+ 
+   // -mrtd option
+   if (Arg *A = Args.getLastArg(OPT_mrtd)) {
+     if (Opts.getDefaultCallingConv() != LangOptions::DCC_None)
+       Diags.Report(diag::err_drv_argument_not_allowed_with)
+           << A->getSpelling() << "-fdefault-calling-conv";
+     else {
+       llvm::Triple T(TargetOpts.Triple);
+       if (T.getArch() != llvm::Triple::x86)
+         Diags.Report(diag::err_drv_argument_not_allowed_with)
+             << A->getSpelling() << T.getTriple();
+       else
+         Opts.setDefaultCallingConv(LangOptions::DCC_StdCall);
+     }
+   }
+ 
+   // Check if -fopenmp is specified.
+   Opts.OpenMP = Args.hasArg(options::OPT_fopenmp) ? 1 : 0;
+   // Check if -fopenmp-simd is specified.
+   Opts.OpenMPSimd = !Opts.OpenMP && Args.hasFlag(options::OPT_fopenmp_simd,
+                                                  options::OPT_fno_openmp_simd,
+                                                  /*Default=*/false);
+   Opts.OpenMPUseTLS =
+       Opts.OpenMP && !Args.hasArg(options::OPT_fnoopenmp_use_tls);
+   Opts.OpenMPIsDevice =
+       Opts.OpenMP && Args.hasArg(options::OPT_fopenmp_is_device);
+ 
+   if (Opts.OpenMP || Opts.OpenMPSimd) {
+     if (int Version =
+             getLastArgIntValue(Args, OPT_fopenmp_version_EQ,
+                                Opts.OpenMPSimd ? 45 : Opts.OpenMP, Diags))
+       Opts.OpenMP = Version;
+     else if (Opts.OpenMPSimd)
+       Opts.OpenMP = 45;
+     // Provide diagnostic when a given target is not expected to be an OpenMP
+     // device or host.
+     if (!Opts.OpenMPIsDevice) {
+       switch (T.getArch()) {
+       default:
+         break;
+       // Add unsupported host targets here:
+       case llvm::Triple::nvptx:
+       case llvm::Triple::nvptx64:
+         Diags.Report(clang::diag::err_drv_omp_host_target_not_supported)
+             << TargetOpts.Triple;
+         break;
+       }
+     }
+   }
+ 
+   // Set the flag to prevent the implementation from emitting device exception
+   // handling code for those requiring so.
+   if (Opts.OpenMPIsDevice && T.isNVPTX()) {
+     Opts.Exceptions = 0;
+     Opts.CXXExceptions = 0;
+   }
+ 
+   // Get the OpenMP target triples if any.
+   if (Arg *A = Args.getLastArg(options::OPT_fopenmp_targets_EQ)) {
+ 
+     for (unsigned i = 0; i < A->getNumValues(); ++i) {
+       llvm::Triple TT(A->getValue(i));
+ 
+       if (TT.getArch() == llvm::Triple::UnknownArch ||
+           !(TT.getArch() == llvm::Triple::ppc ||
+             TT.getArch() == llvm::Triple::ppc64 ||
+             TT.getArch() == llvm::Triple::ppc64le ||
+             TT.getArch() == llvm::Triple::nvptx ||
+             TT.getArch() == llvm::Triple::nvptx64 ||
+             TT.getArch() == llvm::Triple::x86 ||
+             TT.getArch() == llvm::Triple::x86_64))
+         Diags.Report(clang::diag::err_drv_invalid_omp_target) << A->getValue(i);
+       else
+         Opts.OMPTargetTriples.push_back(TT);
+     }
+   }
+ 
+   // Get OpenMP host file path if any and report if a non existent file is
+   // found
+   if (Arg *A = Args.getLastArg(options::OPT_fopenmp_host_ir_file_path)) {
+     Opts.OMPHostIRFile = A->getValue();
+     if (!llvm::sys::fs::exists(Opts.OMPHostIRFile))
+       Diags.Report(clang::diag::err_drv_omp_host_ir_file_not_found)
+           << Opts.OMPHostIRFile;
+   }
+ 
+   // Record whether the __DEPRECATED define was requested.
+   Opts.Deprecated = Args.hasFlag(OPT_fdeprecated_macro,
+                                  OPT_fno_deprecated_macro,
+                                  Opts.Deprecated);
+ 
+   // FIXME: Eliminate this dependency.
+   unsigned Opt = getOptimizationLevel(Args, IK, Diags),
+        OptSize = getOptimizationLevelSize(Args);
+   Opts.Optimize = Opt != 0;
+   Opts.OptimizeSize = OptSize != 0;
+ 
+   // This is the __NO_INLINE__ define, which just depends on things like the
+   // optimization level and -fno-inline, not actually whether the backend has
+   // inlining enabled.
+   Opts.NoInlineDefine = !Opts.Optimize;
+   if (Arg *InlineArg = Args.getLastArg(
+           options::OPT_finline_functions, options::OPT_finline_hint_functions,
+           options::OPT_fno_inline_functions, options::OPT_fno_inline))
+     if (InlineArg->getOption().matches(options::OPT_fno_inline))
+       Opts.NoInlineDefine = true;
+ 
+   Opts.FastMath = Args.hasArg(OPT_ffast_math) ||
+       Args.hasArg(OPT_cl_fast_relaxed_math);
+   Opts.FiniteMathOnly = Args.hasArg(OPT_ffinite_math_only) ||
+       Args.hasArg(OPT_cl_finite_math_only) ||
+       Args.hasArg(OPT_cl_fast_relaxed_math);
+   Opts.UnsafeFPMath = Args.hasArg(OPT_menable_unsafe_fp_math) ||
+                       Args.hasArg(OPT_cl_unsafe_math_optimizations) ||
+                       Args.hasArg(OPT_cl_fast_relaxed_math);
+ 
+   if (Arg *A = Args.getLastArg(OPT_ffp_contract)) {
+     StringRef Val = A->getValue();
+     if (Val == "fast")
+       Opts.setDefaultFPContractMode(LangOptions::FPC_Fast);
+     else if (Val == "on")
+       Opts.setDefaultFPContractMode(LangOptions::FPC_On);
+     else if (Val == "off")
+       Opts.setDefaultFPContractMode(LangOptions::FPC_Off);
+     else
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Val;
+   }
+ 
+   Opts.RetainCommentsFromSystemHeaders =
+       Args.hasArg(OPT_fretain_comments_from_system_headers);
+ 
+   unsigned SSP = getLastArgIntValue(Args, OPT_stack_protector, 0, Diags);
+   switch (SSP) {
+   default:
+     Diags.Report(diag::err_drv_invalid_value)
+       << Args.getLastArg(OPT_stack_protector)->getAsString(Args) << SSP;
+     break;
+   case 0: Opts.setStackProtector(LangOptions::SSPOff); break;
+   case 1: Opts.setStackProtector(LangOptions::SSPOn);  break;
+   case 2: Opts.setStackProtector(LangOptions::SSPStrong); break;
+   case 3: Opts.setStackProtector(LangOptions::SSPReq); break;
+   }
+ 
+   // Parse -fsanitize= arguments.
+   parseSanitizerKinds("-fsanitize=", Args.getAllArgValues(OPT_fsanitize_EQ),
+                       Diags, Opts.Sanitize);
+   // -fsanitize-address-field-padding=N has to be a LangOpt, parse it here.
+   Opts.SanitizeAddressFieldPadding =
+       getLastArgIntValue(Args, OPT_fsanitize_address_field_padding, 0, Diags);
+   Opts.SanitizerBlacklistFiles = Args.getAllArgValues(OPT_fsanitize_blacklist);
+ 
+   // -fxray-instrument
+   Opts.XRayInstrument =
+       Args.hasFlag(OPT_fxray_instrument, OPT_fnoxray_instrument, false);
+ 
+   // -fxray-always-emit-customevents
+   Opts.XRayAlwaysEmitCustomEvents =
+       Args.hasFlag(OPT_fxray_always_emit_customevents,
+                    OPT_fnoxray_always_emit_customevents, false);
+ 
+   // -fxray-{always,never}-instrument= filenames.
+   Opts.XRayAlwaysInstrumentFiles =
+       Args.getAllArgValues(OPT_fxray_always_instrument);
+   Opts.XRayNeverInstrumentFiles =
+       Args.getAllArgValues(OPT_fxray_never_instrument);
+ 
+   // -fallow-editor-placeholders
+   Opts.AllowEditorPlaceholders = Args.hasArg(OPT_fallow_editor_placeholders);
+ }
+ 
+ static bool isStrictlyPreprocessorAction(frontend::ActionKind Action) {
+   switch (Action) {
+   case frontend::ASTDeclList:
+   case frontend::ASTDump:
+   case frontend::ASTPrint:
+   case frontend::ASTView:
+   case frontend::EmitAssembly:
+   case frontend::EmitBC:
+   case frontend::EmitHTML:
+   case frontend::EmitLLVM:
+   case frontend::EmitLLVMOnly:
+   case frontend::EmitCodeGenOnly:
+   case frontend::EmitObj:
+   case frontend::FixIt:
+   case frontend::GenerateModule:
+   case frontend::GenerateModuleInterface:
+   case frontend::GeneratePCH:
+   case frontend::GeneratePTH:
+   case frontend::ParseSyntaxOnly:
+   case frontend::ModuleFileInfo:
+   case frontend::VerifyPCH:
+   case frontend::PluginAction:
+   case frontend::PrintDeclContext:
+   case frontend::RewriteObjC:
+   case frontend::RewriteTest:
+   case frontend::RunAnalysis:
+   case frontend::TemplightDump:
+   case frontend::MigrateSource:
+     return false;
+ 
+   case frontend::DumpRawTokens:
+   case frontend::DumpTokens:
+   case frontend::InitOnly:
+   case frontend::PrintPreamble:
+   case frontend::PrintPreprocessedInput:
+   case frontend::RewriteMacros:
+   case frontend::RunPreprocessorOnly:
+     return true;
+   }
+   llvm_unreachable("invalid frontend action");
+ }
+ 
+ static void ParsePreprocessorArgs(PreprocessorOptions &Opts, ArgList &Args,
+                                   DiagnosticsEngine &Diags,
+                                   frontend::ActionKind Action) {
+   using namespace options;
+   Opts.ImplicitPCHInclude = Args.getLastArgValue(OPT_include_pch);
+   Opts.ImplicitPTHInclude = Args.getLastArgValue(OPT_include_pth);
+   if (const Arg *A = Args.getLastArg(OPT_token_cache))
+       Opts.TokenCache = A->getValue();
+   else
+     Opts.TokenCache = Opts.ImplicitPTHInclude;
+   Opts.UsePredefines = !Args.hasArg(OPT_undef);
+   Opts.DetailedRecord = Args.hasArg(OPT_detailed_preprocessing_record);
+   Opts.DisablePCHValidation = Args.hasArg(OPT_fno_validate_pch);
+   Opts.AllowPCHWithCompilerErrors = Args.hasArg(OPT_fallow_pch_with_errors);
+ 
+   Opts.DumpDeserializedPCHDecls = Args.hasArg(OPT_dump_deserialized_pch_decls);
+   for (const Arg *A : Args.filtered(OPT_error_on_deserialized_pch_decl))
+     Opts.DeserializedPCHDeclsToErrorOn.insert(A->getValue());
+ 
+   if (const Arg *A = Args.getLastArg(OPT_preamble_bytes_EQ)) {
+     StringRef Value(A->getValue());
+     size_t Comma = Value.find(',');
+     unsigned Bytes = 0;
+     unsigned EndOfLine = 0;
+ 
+     if (Comma == StringRef::npos ||
+         Value.substr(0, Comma).getAsInteger(10, Bytes) ||
+         Value.substr(Comma + 1).getAsInteger(10, EndOfLine))
+       Diags.Report(diag::err_drv_preamble_format);
+     else {
+       Opts.PrecompiledPreambleBytes.first = Bytes;
+       Opts.PrecompiledPreambleBytes.second = (EndOfLine != 0);
+     }
+   }
+ 
+   // Add macros from the command line.
+   for (const Arg *A : Args.filtered(OPT_D, OPT_U)) {
+     if (A->getOption().matches(OPT_D))
+       Opts.addMacroDef(A->getValue());
+     else
+       Opts.addMacroUndef(A->getValue());
+   }
+ 
+   Opts.MacroIncludes = Args.getAllArgValues(OPT_imacros);
+ 
+   // Add the ordered list of -includes.
+   for (const Arg *A : Args.filtered(OPT_include))
+     Opts.Includes.emplace_back(A->getValue());
+ 
+   for (const Arg *A : Args.filtered(OPT_chain_include))
+     Opts.ChainedIncludes.emplace_back(A->getValue());
+ 
+   for (const Arg *A : Args.filtered(OPT_remap_file)) {
+     std::pair<StringRef, StringRef> Split = StringRef(A->getValue()).split(';');
+ 
+     if (Split.second.empty()) {
+       Diags.Report(diag::err_drv_invalid_remap_file) << A->getAsString(Args);
+       continue;
+     }
+ 
+     Opts.addRemappedFile(Split.first, Split.second);
+   }
+ 
+   if (Arg *A = Args.getLastArg(OPT_fobjc_arc_cxxlib_EQ)) {
+     StringRef Name = A->getValue();
+     unsigned Library = llvm::StringSwitch<unsigned>(Name)
+       .Case("libc++", ARCXX_libcxx)
+       .Case("libstdc++", ARCXX_libstdcxx)
+       .Case("none", ARCXX_nolib)
+       .Default(~0U);
+     if (Library == ~0U)
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args) << Name;
+     else
+       Opts.ObjCXXARCStandardLibrary = (ObjCXXARCStandardLibraryKind)Library;
+   }
+ 
+   // Always avoid lexing editor placeholders when we're just running the
+   // preprocessor as we never want to emit the
+   // "editor placeholder in source file" error in PP only mode.
+   if (isStrictlyPreprocessorAction(Action))
+     Opts.LexEditorPlaceholders = false;
+ }
+ 
+ static void ParsePreprocessorOutputArgs(PreprocessorOutputOptions &Opts,
+                                         ArgList &Args,
+                                         frontend::ActionKind Action) {
+   using namespace options;
+ 
+   if (isStrictlyPreprocessorAction(Action))
+     Opts.ShowCPP = !Args.hasArg(OPT_dM);
+   else
+     Opts.ShowCPP = 0;
+ 
+   Opts.ShowComments = Args.hasArg(OPT_C);
+   Opts.ShowLineMarkers = !Args.hasArg(OPT_P);
+   Opts.ShowMacroComments = Args.hasArg(OPT_CC);
+   Opts.ShowMacros = Args.hasArg(OPT_dM) || Args.hasArg(OPT_dD);
+   Opts.ShowIncludeDirectives = Args.hasArg(OPT_dI);
+   Opts.RewriteIncludes = Args.hasArg(OPT_frewrite_includes);
+   Opts.RewriteImports = Args.hasArg(OPT_frewrite_imports);
+   Opts.UseLineDirectives = Args.hasArg(OPT_fuse_line_directives);
+ }
+ 
+ static void ParseTargetArgs(TargetOptions &Opts, ArgList &Args,
+                             DiagnosticsEngine &Diags) {
+   using namespace options;
+   Opts.ABI = Args.getLastArgValue(OPT_target_abi);
+   if (Arg *A = Args.getLastArg(OPT_meabi)) {
+     StringRef Value = A->getValue();
+     llvm::EABI EABIVersion = llvm::StringSwitch<llvm::EABI>(Value)
+                                  .Case("default", llvm::EABI::Default)
+                                  .Case("4", llvm::EABI::EABI4)
+                                  .Case("5", llvm::EABI::EABI5)
+                                  .Case("gnu", llvm::EABI::GNU)
+                                  .Default(llvm::EABI::Unknown);
+     if (EABIVersion == llvm::EABI::Unknown)
+       Diags.Report(diag::err_drv_invalid_value) << A->getAsString(Args)
+                                                 << Value;
+     else
+       Opts.EABIVersion = EABIVersion;
+   }
+   Opts.CPU = Args.getLastArgValue(OPT_target_cpu);
+   Opts.FPMath = Args.getLastArgValue(OPT_mfpmath);
+   Opts.FeaturesAsWritten = Args.getAllArgValues(OPT_target_feature);
+   Opts.LinkerVersion = Args.getLastArgValue(OPT_target_linker_version);
+   Opts.Triple = llvm::Triple::normalize(Args.getLastArgValue(OPT_triple));
+   // Use the default target triple if unspecified.
+   if (Opts.Triple.empty())
+     Opts.Triple = llvm::sys::getDefaultTargetTriple();
+   Opts.OpenCLExtensionsAsWritten = Args.getAllArgValues(OPT_cl_ext_EQ);
+ }
+ 
+ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
+                                         const char *const *ArgBegin,
+                                         const char *const *ArgEnd,
+                                         DiagnosticsEngine &Diags) {
+   bool Success = true;
+ 
+   // Parse the arguments.
+   std::unique_ptr<OptTable> Opts = createDriverOptTable();
+   const unsigned IncludedFlagsBitmask = options::CC1Option;
+   unsigned MissingArgIndex, MissingArgCount;
+   InputArgList Args =
+       Opts->ParseArgs(llvm::makeArrayRef(ArgBegin, ArgEnd), MissingArgIndex,
+                       MissingArgCount, IncludedFlagsBitmask);
+   LangOptions &LangOpts = *Res.getLangOpts();
+ 
+   // Check for missing argument error.
+   if (MissingArgCount) {
+     Diags.Report(diag::err_drv_missing_argument)
+         << Args.getArgString(MissingArgIndex) << MissingArgCount;
+     Success = false;
+   }
+ 
+   // Issue errors on unknown arguments.
+   for (const Arg *A : Args.filtered(OPT_UNKNOWN)) {
+     auto ArgString = A->getAsString(Args);
+     std::string Nearest;
+     if (Opts->findNearest(ArgString, Nearest, IncludedFlagsBitmask) > 1)
+       Diags.Report(diag::err_drv_unknown_argument) << ArgString;
+     else
+       Diags.Report(diag::err_drv_unknown_argument_with_suggestion)
+           << ArgString << Nearest;
+     Success = false;
+   }
+ 
+   Success &= ParseAnalyzerArgs(*Res.getAnalyzerOpts(), Args, Diags);
+   Success &= ParseMigratorArgs(Res.getMigratorOpts(), Args);
+   ParseDependencyOutputArgs(Res.getDependencyOutputOpts(), Args);
+   Success &=
+       ParseDiagnosticArgs(Res.getDiagnosticOpts(), Args, &Diags,
+                           false /*DefaultDiagColor*/, false /*DefaultShowOpt*/);
+   ParseCommentArgs(LangOpts.CommentOpts, Args);
+   ParseFileSystemArgs(Res.getFileSystemOpts(), Args);
+   // FIXME: We shouldn't have to pass the DashX option around here
+   InputKind DashX = ParseFrontendArgs(Res.getFrontendOpts(), Args, Diags,
+                                       LangOpts.IsHeaderFile);
+   ParseTargetArgs(Res.getTargetOpts(), Args, Diags);
+   Success &= ParseCodeGenArgs(Res.getCodeGenOpts(), Args, DashX, Diags,
+                               Res.getTargetOpts());
+   ParseHeaderSearchArgs(Res.getHeaderSearchOpts(), Args,
+                         Res.getFileSystemOpts().WorkingDir);
+   if (DashX.getFormat() == InputKind::Precompiled ||
+       DashX.getLanguage() == InputKind::LLVM_IR) {
+     // ObjCAAutoRefCount and Sanitize LangOpts are used to setup the
+     // PassManager in BackendUtil.cpp. They need to be initializd no matter
+     // what the input type is.
+     if (Args.hasArg(OPT_fobjc_arc))
+       LangOpts.ObjCAutoRefCount = 1;
+     // PIClevel and PIELevel are needed during code generation and this should be
+     // set regardless of the input type.
+     LangOpts.PICLevel = getLastArgIntValue(Args, OPT_pic_level, 0, Diags);
+     LangOpts.PIE = Args.hasArg(OPT_pic_is_pie);
+     parseSanitizerKinds("-fsanitize=", Args.getAllArgValues(OPT_fsanitize_EQ),
+                         Diags, LangOpts.Sanitize);
+   } else {
+     // Other LangOpts are only initialzed when the input is not AST or LLVM IR.
+     // FIXME: Should we really be calling this for an InputKind::Asm input?
+     ParseLangArgs(LangOpts, Args, DashX, Res.getTargetOpts(),
+                   Res.getPreprocessorOpts(), Diags);
+     if (Res.getFrontendOpts().ProgramAction == frontend::RewriteObjC)
+       LangOpts.ObjCExceptions = 1;
+   }
+ 
+   if (LangOpts.CUDA) {
+     // During CUDA device-side compilation, the aux triple is the
+     // triple used for host compilation.
+     if (LangOpts.CUDAIsDevice)
+       Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
+   }
+ 
+   // Set the triple of the host for OpenMP device compile.
+   if (LangOpts.OpenMPIsDevice)
+     Res.getTargetOpts().HostTriple = Res.getFrontendOpts().AuxTriple;
+ 
+   // FIXME: Override value name discarding when asan or msan is used because the
+   // backend passes depend on the name of the alloca in order to print out
+   // names.
+   Res.getCodeGenOpts().DiscardValueNames &=
+       !LangOpts.Sanitize.has(SanitizerKind::Address) &&
+       !LangOpts.Sanitize.has(SanitizerKind::Memory);
+ 
+   ParsePreprocessorArgs(Res.getPreprocessorOpts(), Args, Diags,
+                         Res.getFrontendOpts().ProgramAction);
+   ParsePreprocessorOutputArgs(Res.getPreprocessorOutputOpts(), Args,
+                               Res.getFrontendOpts().ProgramAction);
+ 
+   // Turn on -Wspir-compat for SPIR target.
+   llvm::Triple T(Res.getTargetOpts().Triple);
+   auto Arch = T.getArch();
+   if (Arch == llvm::Triple::spir || Arch == llvm::Triple::spir64) {
+     Res.getDiagnosticOpts().Warnings.push_back("spir-compat");
+   }
+ 
+   // If sanitizer is enabled, disable OPT_ffine_grained_bitfield_accesses.
+   if (Res.getCodeGenOpts().FineGrainedBitfieldAccesses &&
+       !Res.getLangOpts()->Sanitize.empty()) {
+     Res.getCodeGenOpts().FineGrainedBitfieldAccesses = false;
+     Diags.Report(diag::warn_drv_fine_grained_bitfield_accesses_ignored);
+   }
+   return Success;
+ }
+ 
+ std::string CompilerInvocation::getModuleHash() const {
+   // Note: For QoI reasons, the things we use as a hash here should all be
+   // dumped via the -module-info flag.
+   using llvm::hash_code;
+   using llvm::hash_value;
+   using llvm::hash_combine;
+ 
+   // Start the signature with the compiler version.
+   // FIXME: We'd rather use something more cryptographically sound than
+   // CityHash, but this will do for now.
+   hash_code code = hash_value(getClangFullRepositoryVersion());
+ 
+   // Extend the signature with the language options
+ #define LANGOPT(Name, Bits, Default, Description) \
+    code = hash_combine(code, LangOpts->Name);
+ #define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
+   code = hash_combine(code, static_cast<unsigned>(LangOpts->get##Name()));
+ #define BENIGN_LANGOPT(Name, Bits, Default, Description)
+ #define BENIGN_ENUM_LANGOPT(Name, Type, Bits, Default, Description)
+ #include "clang/Basic/LangOptions.def"
+ 
+   for (StringRef Feature : LangOpts->ModuleFeatures)
+     code = hash_combine(code, Feature);
+ 
+   // Extend the signature with the target options.
+   code = hash_combine(code, TargetOpts->Triple, TargetOpts->CPU,
+                       TargetOpts->ABI);
+   for (unsigned i = 0, n = TargetOpts->FeaturesAsWritten.size(); i != n; ++i)
+     code = hash_combine(code, TargetOpts->FeaturesAsWritten[i]);
+ 
+   // Extend the signature with preprocessor options.
+   const PreprocessorOptions &ppOpts = getPreprocessorOpts();
+   const HeaderSearchOptions &hsOpts = getHeaderSearchOpts();
+   code = hash_combine(code, ppOpts.UsePredefines, ppOpts.DetailedRecord);
+ 
+   for (std::vector<std::pair<std::string, bool/*isUndef*/>>::const_iterator
+             I = getPreprocessorOpts().Macros.begin(),
+          IEnd = getPreprocessorOpts().Macros.end();
+        I != IEnd; ++I) {
+     // If we're supposed to ignore this macro for the purposes of modules,
+     // don't put it into the hash.
+     if (!hsOpts.ModulesIgnoreMacros.empty()) {
+       // Check whether we're ignoring this macro.
+       StringRef MacroDef = I->first;
+       if (hsOpts.ModulesIgnoreMacros.count(
+               llvm::CachedHashString(MacroDef.split('=').first)))
+         continue;
+     }
+ 
+     code = hash_combine(code, I->first, I->second);
+   }
+ 
+   // Extend the signature with the sysroot and other header search options.
+   code = hash_combine(code, hsOpts.Sysroot,
+                       hsOpts.ModuleFormat,
+                       hsOpts.UseDebugInfo,
+                       hsOpts.UseBuiltinIncludes,
+                       hsOpts.UseStandardSystemIncludes,
+                       hsOpts.UseStandardCXXIncludes,
+                       hsOpts.UseLibcxx,
+                       hsOpts.ModulesValidateDiagnosticOptions);
+   code = hash_combine(code, hsOpts.ResourceDir);
+ 
+   // Extend the signature with the user build path.
+   code = hash_combine(code, hsOpts.ModuleUserBuildPath);
+ 
+   // Extend the signature with the module file extensions.
+   const FrontendOptions &frontendOpts = getFrontendOpts();
+   for (const auto &ext : frontendOpts.ModuleFileExtensions) {
+     code = ext->hashExtension(code);
+   }
+ 
+   // Extend the signature with the enabled sanitizers, if at least one is
+   // enabled. Sanitizers which cannot affect AST generation aren't hashed.
+   SanitizerSet SanHash = LangOpts->Sanitize;
+   SanHash.clear(getPPTransparentSanitizers());
+   if (!SanHash.empty())
+     code = hash_combine(code, SanHash.Mask);
+ 
+   return llvm::APInt(64, code).toString(36, /*Signed=*/false);
+ }
+ 
+ namespace clang {
+ 
+ template<typename IntTy>
+ static IntTy getLastArgIntValueImpl(const ArgList &Args, OptSpecifier Id,
+                                     IntTy Default,
+                                     DiagnosticsEngine *Diags) {
+   IntTy Res = Default;
+   if (Arg *A = Args.getLastArg(Id)) {
+     if (StringRef(A->getValue()).getAsInteger(10, Res)) {
+       if (Diags)
+         Diags->Report(diag::err_drv_invalid_int_value) << A->getAsString(Args)
+                                                        << A->getValue();
+     }
+   }
+   return Res;
+ }
+ 
+ 
+ // Declared in clang/Frontend/Utils.h.
+ int getLastArgIntValue(const ArgList &Args, OptSpecifier Id, int Default,
+                        DiagnosticsEngine *Diags) {
+   return getLastArgIntValueImpl<int>(Args, Id, Default, Diags);
+ }
+ 
+ uint64_t getLastArgUInt64Value(const ArgList &Args, OptSpecifier Id,
+                                uint64_t Default,
+                                DiagnosticsEngine *Diags) {
+   return getLastArgIntValueImpl<uint64_t>(Args, Id, Default, Diags);
+ }
+ 
+ void BuryPointer(const void *Ptr) {
+   // This function may be called only a small fixed amount of times per each
+   // invocation, otherwise we do actually have a leak which we want to report.
+   // If this function is called more than kGraveYardMaxSize times, the pointers
+   // will not be properly buried and a leak detector will report a leak, which
+   // is what we want in such case.
+   static const size_t kGraveYardMaxSize = 16;
+   LLVM_ATTRIBUTE_UNUSED static const void *GraveYard[kGraveYardMaxSize];
+   static std::atomic<unsigned> GraveYardSize;
+   unsigned Idx = GraveYardSize++;
+   if (Idx >= kGraveYardMaxSize)
+     return;
+   GraveYard[Idx] = Ptr;
+ }
+ 
+ IntrusiveRefCntPtr<vfs::FileSystem>
+ createVFSFromCompilerInvocation(const CompilerInvocation &CI,
+                                 DiagnosticsEngine &Diags) {
+   return createVFSFromCompilerInvocation(CI, Diags, vfs::getRealFileSystem());
+ }
+ 
+ IntrusiveRefCntPtr<vfs::FileSystem>
+ createVFSFromCompilerInvocation(const CompilerInvocation &CI,
+                                 DiagnosticsEngine &Diags,
+                                 IntrusiveRefCntPtr<vfs::FileSystem> BaseFS) {
+   if (CI.getHeaderSearchOpts().VFSOverlayFiles.empty())
+     return BaseFS;
+ 
+   IntrusiveRefCntPtr<vfs::OverlayFileSystem> Overlay(
+       new vfs::OverlayFileSystem(BaseFS));
+   // earlier vfs files are on the bottom
+   for (const std::string &File : CI.getHeaderSearchOpts().VFSOverlayFiles) {
+     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buffer =
+         BaseFS->getBufferForFile(File);
+     if (!Buffer) {
+       Diags.Report(diag::err_missing_vfs_overlay_file) << File;
+       return IntrusiveRefCntPtr<vfs::FileSystem>();
+     }
+ 
+     IntrusiveRefCntPtr<vfs::FileSystem> FS = vfs::getVFSFromYAML(
+         std::move(Buffer.get()), /*DiagHandler*/ nullptr, File);
+     if (!FS.get()) {
+       Diags.Report(diag::err_invalid_vfs_overlay) << File;
+       return IntrusiveRefCntPtr<vfs::FileSystem>();
+     }
+     Overlay->pushOverlay(FS);
+   }
+   return Overlay;
+ }
+ } // end namespace clang
+diff --git a/lib/Frontend/FrontendActions.cpp b/lib/Frontend/FrontendActions.cpp
+index 1eff566..505faf5 100644
+--- a/lib/Frontend/FrontendActions.cpp
++++ b/lib/Frontend/FrontendActions.cpp
+@@ -1,756 +1,789 @@
+ //===--- FrontendActions.cpp ----------------------------------------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+ //
+ // This file is distributed under the University of Illinois Open Source
+ // License. See LICENSE.TXT for details.
+ //
+ //===----------------------------------------------------------------------===//
+ 
+ #include "clang/Frontend/FrontendActions.h"
+ #include "clang/AST/ASTConsumer.h"
+ #include "clang/Basic/FileManager.h"
+ #include "clang/Frontend/ASTConsumers.h"
+ #include "clang/Frontend/CompilerInstance.h"
+ #include "clang/Frontend/FrontendDiagnostic.h"
+ #include "clang/Frontend/MultiplexConsumer.h"
+ #include "clang/Frontend/Utils.h"
+ #include "clang/Lex/HeaderSearch.h"
+ #include "clang/Lex/Preprocessor.h"
+ #include "clang/Lex/PreprocessorOptions.h"
+ #include "clang/Sema/TemplateInstCallback.h"
+ #include "clang/Serialization/ASTReader.h"
+ #include "clang/Serialization/ASTWriter.h"
+ #include "llvm/Support/FileSystem.h"
+ #include "llvm/Support/MemoryBuffer.h"
+ #include "llvm/Support/Path.h"
+ #include "llvm/Support/raw_ostream.h"
+ #include "llvm/Support/YAMLTraits.h"
++#include <chrono>
+ #include <memory>
+ #include <system_error>
+ 
+ using namespace clang;
+ 
+ namespace {
+ CodeCompleteConsumer *GetCodeCompletionConsumer(CompilerInstance &CI) {
+   return CI.hasCodeCompletionConsumer() ? &CI.getCodeCompletionConsumer()
+                                         : nullptr;
+ }
+ 
+ void EnsureSemaIsCreated(CompilerInstance &CI, FrontendAction &Action) {
+   if (Action.hasCodeCompletionSupport() &&
+       !CI.getFrontendOpts().CodeCompletionAt.FileName.empty())
+     CI.createCodeCompletionConsumer();
+ 
+   if (!CI.hasSema())
+     CI.createSema(Action.getTranslationUnitKind(),
+                   GetCodeCompletionConsumer(CI));
+ }
+ } // namespace
+ 
+ //===----------------------------------------------------------------------===//
+ // Custom Actions
+ //===----------------------------------------------------------------------===//
+ 
+ std::unique_ptr<ASTConsumer>
+ InitOnlyAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return llvm::make_unique<ASTConsumer>();
+ }
+ 
+ void InitOnlyAction::ExecuteAction() {
+ }
+ 
+ //===----------------------------------------------------------------------===//
+ // AST Consumer Actions
+ //===----------------------------------------------------------------------===//
+ 
+ std::unique_ptr<ASTConsumer>
+ ASTPrintAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   if (std::unique_ptr<raw_ostream> OS =
+           CI.createDefaultOutputFile(false, InFile))
+     return CreateASTPrinter(std::move(OS), CI.getFrontendOpts().ASTDumpFilter);
+   return nullptr;
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ ASTDumpAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return CreateASTDumper(CI.getFrontendOpts().ASTDumpFilter,
+                          CI.getFrontendOpts().ASTDumpDecls,
+                          CI.getFrontendOpts().ASTDumpAll,
+                          CI.getFrontendOpts().ASTDumpLookups);
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ ASTDeclListAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return CreateASTDeclNodeLister();
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ ASTViewAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return CreateASTViewer();
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ DeclContextPrintAction::CreateASTConsumer(CompilerInstance &CI,
+                                           StringRef InFile) {
+   return CreateDeclContextPrinter();
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ GeneratePCHAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   std::string Sysroot;
+   if (!ComputeASTConsumerArguments(CI, /*ref*/ Sysroot))
+     return nullptr;
+ 
+   std::string OutputFile;
+   std::unique_ptr<raw_pwrite_stream> OS =
+       CreateOutputFile(CI, InFile, /*ref*/ OutputFile);
+   if (!OS)
+     return nullptr;
+ 
+   if (!CI.getFrontendOpts().RelocatablePCH)
+     Sysroot.clear();
+ 
+   auto Buffer = std::make_shared<PCHBuffer>();
+   std::vector<std::unique_ptr<ASTConsumer>> Consumers;
+   Consumers.push_back(llvm::make_unique<PCHGenerator>(
+                         CI.getPreprocessor(), OutputFile, Sysroot,
+                         Buffer, CI.getFrontendOpts().ModuleFileExtensions,
+       /*AllowASTWithErrors*/CI.getPreprocessorOpts().AllowPCHWithCompilerErrors,
+                         /*IncludeTimestamps*/
+                           +CI.getFrontendOpts().IncludeTimestamps));
+   Consumers.push_back(CI.getPCHContainerWriter().CreatePCHContainerGenerator(
+       CI, InFile, OutputFile, std::move(OS), Buffer));
+ 
+   return llvm::make_unique<MultiplexConsumer>(std::move(Consumers));
+ }
+ 
+ bool GeneratePCHAction::ComputeASTConsumerArguments(CompilerInstance &CI,
+                                                     std::string &Sysroot) {
+   Sysroot = CI.getHeaderSearchOpts().Sysroot;
+   if (CI.getFrontendOpts().RelocatablePCH && Sysroot.empty()) {
+     CI.getDiagnostics().Report(diag::err_relocatable_without_isysroot);
+     return false;
+   }
+ 
+   return true;
+ }
+ 
+ std::unique_ptr<llvm::raw_pwrite_stream>
+ GeneratePCHAction::CreateOutputFile(CompilerInstance &CI, StringRef InFile,
+                                     std::string &OutputFile) {
+   // We use createOutputFile here because this is exposed via libclang, and we
+   // must disable the RemoveFileOnSignal behavior.
+   // We use a temporary to avoid race conditions.
+   std::unique_ptr<raw_pwrite_stream> OS =
+       CI.createOutputFile(CI.getFrontendOpts().OutputFile, /*Binary=*/true,
+                           /*RemoveFileOnSignal=*/false, InFile,
+                           /*Extension=*/"", /*useTemporary=*/true);
+   if (!OS)
+     return nullptr;
+ 
+   OutputFile = CI.getFrontendOpts().OutputFile;
+   return OS;
+ }
+ 
+ bool GeneratePCHAction::shouldEraseOutputFiles() {
+   if (getCompilerInstance().getPreprocessorOpts().AllowPCHWithCompilerErrors)
+     return false;
+   return ASTFrontendAction::shouldEraseOutputFiles();
+ }
+ 
+ bool GeneratePCHAction::BeginSourceFileAction(CompilerInstance &CI) {
+   CI.getLangOpts().CompilingPCH = true;
+   return true;
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ GenerateModuleAction::CreateASTConsumer(CompilerInstance &CI,
+                                         StringRef InFile) {
+   std::unique_ptr<raw_pwrite_stream> OS = CreateOutputFile(CI, InFile);
+   if (!OS)
+     return nullptr;
+ 
+   std::string OutputFile = CI.getFrontendOpts().OutputFile;
+   std::string Sysroot;
+ 
+   auto Buffer = std::make_shared<PCHBuffer>();
+   std::vector<std::unique_ptr<ASTConsumer>> Consumers;
+ 
+   Consumers.push_back(llvm::make_unique<PCHGenerator>(
+                         CI.getPreprocessor(), OutputFile, Sysroot,
+                         Buffer, CI.getFrontendOpts().ModuleFileExtensions,
+                         /*AllowASTWithErrors=*/false,
+                         /*IncludeTimestamps=*/
+                           +CI.getFrontendOpts().BuildingImplicitModule));
+   Consumers.push_back(CI.getPCHContainerWriter().CreatePCHContainerGenerator(
+       CI, InFile, OutputFile, std::move(OS), Buffer));
+   return llvm::make_unique<MultiplexConsumer>(std::move(Consumers));
+ }
+ 
+ bool GenerateModuleFromModuleMapAction::BeginSourceFileAction(
+     CompilerInstance &CI) {
+   if (!CI.getLangOpts().Modules) {
+     CI.getDiagnostics().Report(diag::err_module_build_requires_fmodules);
+     return false;
+   }
+ 
+   return GenerateModuleAction::BeginSourceFileAction(CI);
+ }
+ 
+ std::unique_ptr<raw_pwrite_stream>
+ GenerateModuleFromModuleMapAction::CreateOutputFile(CompilerInstance &CI,
+                                                     StringRef InFile) {
+   // If no output file was provided, figure out where this module would go
+   // in the module cache.
+   if (CI.getFrontendOpts().OutputFile.empty()) {
+     StringRef ModuleMapFile = CI.getFrontendOpts().OriginalModuleMap;
+     if (ModuleMapFile.empty())
+       ModuleMapFile = InFile;
+ 
+     HeaderSearch &HS = CI.getPreprocessor().getHeaderSearchInfo();
+     CI.getFrontendOpts().OutputFile =
+         HS.getCachedModuleFileName(CI.getLangOpts().CurrentModule,
+                                    ModuleMapFile);
+   }
+ 
+   // We use createOutputFile here because this is exposed via libclang, and we
+   // must disable the RemoveFileOnSignal behavior.
+   // We use a temporary to avoid race conditions.
+   return CI.createOutputFile(CI.getFrontendOpts().OutputFile, /*Binary=*/true,
+                              /*RemoveFileOnSignal=*/false, InFile,
+                              /*Extension=*/"", /*useTemporary=*/true,
+                              /*CreateMissingDirectories=*/true);
+ }
+ 
+ bool GenerateModuleInterfaceAction::BeginSourceFileAction(
+     CompilerInstance &CI) {
+   if (!CI.getLangOpts().ModulesTS) {
+     CI.getDiagnostics().Report(diag::err_module_interface_requires_modules_ts);
+     return false;
+   }
+ 
+   CI.getLangOpts().setCompilingModule(LangOptions::CMK_ModuleInterface);
+ 
+   return GenerateModuleAction::BeginSourceFileAction(CI);
+ }
+ 
+ std::unique_ptr<raw_pwrite_stream>
+ GenerateModuleInterfaceAction::CreateOutputFile(CompilerInstance &CI,
+                                                 StringRef InFile) {
+   return CI.createDefaultOutputFile(/*Binary=*/true, InFile, "pcm");
+ }
+ 
+ SyntaxOnlyAction::~SyntaxOnlyAction() {
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ SyntaxOnlyAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return llvm::make_unique<ASTConsumer>();
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ DumpModuleInfoAction::CreateASTConsumer(CompilerInstance &CI,
+                                         StringRef InFile) {
+   return llvm::make_unique<ASTConsumer>();
+ }
+ 
+ std::unique_ptr<ASTConsumer>
+ VerifyPCHAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return llvm::make_unique<ASTConsumer>();
+ }
+ 
+ void VerifyPCHAction::ExecuteAction() {
+   CompilerInstance &CI = getCompilerInstance();
+   bool Preamble = CI.getPreprocessorOpts().PrecompiledPreambleBytes.first != 0;
+   const std::string &Sysroot = CI.getHeaderSearchOpts().Sysroot;
+   std::unique_ptr<ASTReader> Reader(new ASTReader(
+       CI.getPreprocessor(), &CI.getASTContext(), CI.getPCHContainerReader(),
+       CI.getFrontendOpts().ModuleFileExtensions,
+       Sysroot.empty() ? "" : Sysroot.c_str(),
+       /*DisableValidation*/ false,
+       /*AllowPCHWithCompilerErrors*/ false,
+       /*AllowConfigurationMismatch*/ true,
+       /*ValidateSystemInputs*/ true));
+ 
+   Reader->ReadAST(getCurrentFile(),
+                   Preamble ? serialization::MK_Preamble
+                            : serialization::MK_PCH,
+                   SourceLocation(),
+                   ASTReader::ARR_ConfigurationMismatch);
+ }
+ 
+ namespace {
+ struct TemplightEntry {
+   std::string Name;
+   std::string Kind;
+   std::string Event;
+   std::string DefinitionLocation;
+   std::string PointOfInstantiation;
++  std::chrono::high_resolution_clock::rep TimeStamp;
+ };
+ } // namespace
+ 
+ namespace llvm {
+ namespace yaml {
+ template <> struct MappingTraits<TemplightEntry> {
+-  static void mapping(IO &io, TemplightEntry &fields) {
+-    io.mapRequired("name", fields.Name);
+-    io.mapRequired("kind", fields.Kind);
+-    io.mapRequired("event", fields.Event);
+-    io.mapRequired("orig", fields.DefinitionLocation);
+-    io.mapRequired("poi", fields.PointOfInstantiation);
+-  }
++  static void mapping(IO &io, TemplightEntry &fields);
+ };
+ } // namespace yaml
+ } // namespace llvm
+ 
+ namespace {
+ class DefaultTemplateInstCallback : public TemplateInstantiationCallback {
+   using CodeSynthesisContext = Sema::CodeSynthesisContext;
+ 
+ public:
+   void initialize(const Sema &) override {}
+ 
+   void finalize(const Sema &) override {}
+ 
+   void atTemplateBegin(const Sema &TheSema,
+                        const CodeSynthesisContext &Inst) override {
+     displayTemplightEntry<true>(llvm::outs(), TheSema, Inst);
+   }
+ 
+   void atTemplateEnd(const Sema &TheSema,
+                      const CodeSynthesisContext &Inst) override {
+     displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
+   }
++  
++  static void enableProfiling() {
++    IsProfilingEnabled = true;
++  }
++  static bool isProfilingEnabled() {
++    return IsProfilingEnabled;
++  }
++  static const std::chrono::time_point<std::chrono::high_resolution_clock> start;
+ 
+ private:
++
++  static bool IsProfilingEnabled;
++  
+   static std::string toString(CodeSynthesisContext::SynthesisKind Kind) {
+     switch (Kind) {
+     case CodeSynthesisContext::TemplateInstantiation:
+       return "TemplateInstantiation";
+     case CodeSynthesisContext::DefaultTemplateArgumentInstantiation:
+       return "DefaultTemplateArgumentInstantiation";
+     case CodeSynthesisContext::DefaultFunctionArgumentInstantiation:
+       return "DefaultFunctionArgumentInstantiation";
+     case CodeSynthesisContext::ExplicitTemplateArgumentSubstitution:
+       return "ExplicitTemplateArgumentSubstitution";
+     case CodeSynthesisContext::DeducedTemplateArgumentSubstitution:
+       return "DeducedTemplateArgumentSubstitution";
+     case CodeSynthesisContext::PriorTemplateArgumentSubstitution:
+       return "PriorTemplateArgumentSubstitution";
+     case CodeSynthesisContext::DefaultTemplateArgumentChecking:
+       return "DefaultTemplateArgumentChecking";
+     case CodeSynthesisContext::ExceptionSpecInstantiation:
+       return "ExceptionSpecInstantiation";
+     case CodeSynthesisContext::DeclaringSpecialMember:
+       return "DeclaringSpecialMember";
+     case CodeSynthesisContext::DefiningSynthesizedFunction:
+       return "DefiningSynthesizedFunction";
+     case CodeSynthesisContext::Memoization:
+       return "Memoization";
+     }
+     return "";
+   }
+ 
+   template <bool BeginInstantiation>
+   static void displayTemplightEntry(llvm::raw_ostream &Out, const Sema &TheSema,
+                                     const CodeSynthesisContext &Inst) {
+     std::string YAML;
+     {
+       llvm::raw_string_ostream OS(YAML);
+       llvm::yaml::Output YO(OS);
+       TemplightEntry Entry =
+           getTemplightEntry<BeginInstantiation>(TheSema, Inst);
+       llvm::yaml::EmptyContext Context;
+       llvm::yaml::yamlize(YO, Entry, true, Context);
+     }
+     Out << "---" << YAML << "\n";
+   }
+ 
+   template <bool BeginInstantiation>
+   static TemplightEntry getTemplightEntry(const Sema &TheSema,
+                                           const CodeSynthesisContext &Inst) {
+     TemplightEntry Entry;
++    if (IsProfilingEnabled){
++      auto end = std::chrono::high_resolution_clock::now();
++      Entry.TimeStamp = std::chrono::nanoseconds(end-start).count();
++    }
+     Entry.Kind = toString(Inst.Kind);
+     Entry.Event = BeginInstantiation ? "Begin" : "End";
+     if (auto *NamedTemplate = dyn_cast_or_null<NamedDecl>(Inst.Entity)) {
+       llvm::raw_string_ostream OS(Entry.Name);
+       NamedTemplate->getNameForDiagnostic(OS, TheSema.getLangOpts(), true);
+       const PresumedLoc DefLoc = 
+         TheSema.getSourceManager().getPresumedLoc(Inst.Entity->getLocation());
+       if(!DefLoc.isInvalid())
+         Entry.DefinitionLocation = std::string(DefLoc.getFilename()) + ":" +
+                                    std::to_string(DefLoc.getLine()) + ":" +
+                                    std::to_string(DefLoc.getColumn());
+     }
+     const PresumedLoc PoiLoc =
+         TheSema.getSourceManager().getPresumedLoc(Inst.PointOfInstantiation);
+     if (!PoiLoc.isInvalid()) {
+       Entry.PointOfInstantiation = std::string(PoiLoc.getFilename()) + ":" +
+                                    std::to_string(PoiLoc.getLine()) + ":" +
+                                    std::to_string(PoiLoc.getColumn());
+     }
+     return Entry;
+   }
+ };
++
++bool DefaultTemplateInstCallback::IsProfilingEnabled = false;
++const std::chrono::time_point<std::chrono::high_resolution_clock> 
++  DefaultTemplateInstCallback::start = std::chrono::high_resolution_clock::now();
++
+ } // namespace
+ 
++namespace llvm {
++namespace yaml {
++void MappingTraits<TemplightEntry>::mapping(IO &io, TemplightEntry &fields)
++{
++  io.mapRequired("name", fields.Name);
++  io.mapRequired("kind", fields.Kind);
++  io.mapRequired("event", fields.Event);
++  io.mapRequired("orig", fields.DefinitionLocation);
++  io.mapRequired("poi", fields.PointOfInstantiation);
++  if(DefaultTemplateInstCallback::isProfilingEnabled())
++    io.mapRequired("stamp", fields.TimeStamp);
++}
++} // namespace yaml
++} // namespace llvm
++
+ std::unique_ptr<ASTConsumer>
+ TemplightDumpAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+   return llvm::make_unique<ASTConsumer>();
+ }
+ 
+ void TemplightDumpAction::ExecuteAction() {
+   CompilerInstance &CI = getCompilerInstance();
+ 
+   // This part is normally done by ASTFrontEndAction, but needs to happen
+   // before Templight observers can be created
+   // FIXME: Move the truncation aspect of this into Sema, we delayed this till
+   // here so the source manager would be initialized.
+   EnsureSemaIsCreated(CI, *this);
+ 
+   CI.getSema().TemplateInstCallbacks.push_back(
+       llvm::make_unique<DefaultTemplateInstCallback>());
++  if(CI.getFrontendOpts().TemplightProfile)
++    DefaultTemplateInstCallback::enableProfiling();
+   ASTFrontendAction::ExecuteAction();
+ }
+ 
+ namespace {
+   /// \brief AST reader listener that dumps module information for a module
+   /// file.
+   class DumpModuleInfoListener : public ASTReaderListener {
+     llvm::raw_ostream &Out;
+ 
+   public:
+     DumpModuleInfoListener(llvm::raw_ostream &Out) : Out(Out) { }
+ 
+ #define DUMP_BOOLEAN(Value, Text)                       \
+     Out.indent(4) << Text << ": " << (Value? "Yes" : "No") << "\n"
+ 
+     bool ReadFullVersionInformation(StringRef FullVersion) override {
+       Out.indent(2)
+         << "Generated by "
+         << (FullVersion == getClangFullRepositoryVersion()? "this"
+                                                           : "a different")
+         << " Clang: " << FullVersion << "\n";
+       return ASTReaderListener::ReadFullVersionInformation(FullVersion);
+     }
+ 
+     void ReadModuleName(StringRef ModuleName) override {
+       Out.indent(2) << "Module name: " << ModuleName << "\n";
+     }
+     void ReadModuleMapFile(StringRef ModuleMapPath) override {
+       Out.indent(2) << "Module map file: " << ModuleMapPath << "\n";
+     }
+ 
+     bool ReadLanguageOptions(const LangOptions &LangOpts, bool Complain,
+                              bool AllowCompatibleDifferences) override {
+       Out.indent(2) << "Language options:\n";
+ #define LANGOPT(Name, Bits, Default, Description) \
+       DUMP_BOOLEAN(LangOpts.Name, Description);
+ #define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
+       Out.indent(4) << Description << ": "                   \
+                     << static_cast<unsigned>(LangOpts.get##Name()) << "\n";
+ #define VALUE_LANGOPT(Name, Bits, Default, Description) \
+       Out.indent(4) << Description << ": " << LangOpts.Name << "\n";
+ #define BENIGN_LANGOPT(Name, Bits, Default, Description)
+ #define BENIGN_ENUM_LANGOPT(Name, Type, Bits, Default, Description)
+ #include "clang/Basic/LangOptions.def"
+ 
+       if (!LangOpts.ModuleFeatures.empty()) {
+         Out.indent(4) << "Module features:\n";
+         for (StringRef Feature : LangOpts.ModuleFeatures)
+           Out.indent(6) << Feature << "\n";
+       }
+ 
+       return false;
+     }
+ 
+     bool ReadTargetOptions(const TargetOptions &TargetOpts, bool Complain,
+                            bool AllowCompatibleDifferences) override {
+       Out.indent(2) << "Target options:\n";
+       Out.indent(4) << "  Triple: " << TargetOpts.Triple << "\n";
+       Out.indent(4) << "  CPU: " << TargetOpts.CPU << "\n";
+       Out.indent(4) << "  ABI: " << TargetOpts.ABI << "\n";
+ 
+       if (!TargetOpts.FeaturesAsWritten.empty()) {
+         Out.indent(4) << "Target features:\n";
+         for (unsigned I = 0, N = TargetOpts.FeaturesAsWritten.size();
+              I != N; ++I) {
+           Out.indent(6) << TargetOpts.FeaturesAsWritten[I] << "\n";
+         }
+       }
+ 
+       return false;
+     }
+ 
+     bool ReadDiagnosticOptions(IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts,
+                                bool Complain) override {
+       Out.indent(2) << "Diagnostic options:\n";
+ #define DIAGOPT(Name, Bits, Default) DUMP_BOOLEAN(DiagOpts->Name, #Name);
+ #define ENUM_DIAGOPT(Name, Type, Bits, Default) \
+       Out.indent(4) << #Name << ": " << DiagOpts->get##Name() << "\n";
+ #define VALUE_DIAGOPT(Name, Bits, Default) \
+       Out.indent(4) << #Name << ": " << DiagOpts->Name << "\n";
+ #include "clang/Basic/DiagnosticOptions.def"
+ 
+       Out.indent(4) << "Diagnostic flags:\n";
+       for (const std::string &Warning : DiagOpts->Warnings)
+         Out.indent(6) << "-W" << Warning << "\n";
+       for (const std::string &Remark : DiagOpts->Remarks)
+         Out.indent(6) << "-R" << Remark << "\n";
+ 
+       return false;
+     }
+ 
+     bool ReadHeaderSearchOptions(const HeaderSearchOptions &HSOpts,
+                                  StringRef SpecificModuleCachePath,
+                                  bool Complain) override {
+       Out.indent(2) << "Header search options:\n";
+       Out.indent(4) << "System root [-isysroot=]: '" << HSOpts.Sysroot << "'\n";
+       Out.indent(4) << "Resource dir [ -resource-dir=]: '" << HSOpts.ResourceDir << "'\n";
+       Out.indent(4) << "Module Cache: '" << SpecificModuleCachePath << "'\n";
+       DUMP_BOOLEAN(HSOpts.UseBuiltinIncludes,
+                    "Use builtin include directories [-nobuiltininc]");
+       DUMP_BOOLEAN(HSOpts.UseStandardSystemIncludes,
+                    "Use standard system include directories [-nostdinc]");
+       DUMP_BOOLEAN(HSOpts.UseStandardCXXIncludes,
+                    "Use standard C++ include directories [-nostdinc++]");
+       DUMP_BOOLEAN(HSOpts.UseLibcxx,
+                    "Use libc++ (rather than libstdc++) [-stdlib=]");
+       return false;
+     }
+ 
+     bool ReadPreprocessorOptions(const PreprocessorOptions &PPOpts,
+                                  bool Complain,
+                                  std::string &SuggestedPredefines) override {
+       Out.indent(2) << "Preprocessor options:\n";
+       DUMP_BOOLEAN(PPOpts.UsePredefines,
+                    "Uses compiler/target-specific predefines [-undef]");
+       DUMP_BOOLEAN(PPOpts.DetailedRecord,
+                    "Uses detailed preprocessing record (for indexing)");
+ 
+       if (!PPOpts.Macros.empty()) {
+         Out.indent(4) << "Predefined macros:\n";
+       }
+ 
+       for (std::vector<std::pair<std::string, bool/*isUndef*/> >::const_iterator
+              I = PPOpts.Macros.begin(), IEnd = PPOpts.Macros.end();
+            I != IEnd; ++I) {
+         Out.indent(6);
+         if (I->second)
+           Out << "-U";
+         else
+           Out << "-D";
+         Out << I->first << "\n";
+       }
+       return false;
+     }
+ 
+     /// Indicates that a particular module file extension has been read.
+     void readModuleFileExtension(
+            const ModuleFileExtensionMetadata &Metadata) override {
+       Out.indent(2) << "Module file extension '"
+                     << Metadata.BlockName << "' " << Metadata.MajorVersion
+                     << "." << Metadata.MinorVersion;
+       if (!Metadata.UserInfo.empty()) {
+         Out << ": ";
+         Out.write_escaped(Metadata.UserInfo);
+       }
+ 
+       Out << "\n";
+     }
+ #undef DUMP_BOOLEAN
+   };
+ }
+ 
+ bool DumpModuleInfoAction::BeginInvocation(CompilerInstance &CI) {
+   // The Object file reader also supports raw ast files and there is no point in
+   // being strict about the module file format in -module-file-info mode.
+   CI.getHeaderSearchOpts().ModuleFormat = "obj";
+   return true;
+ }
+ 
+ void DumpModuleInfoAction::ExecuteAction() {
+   // Set up the output file.
+   std::unique_ptr<llvm::raw_fd_ostream> OutFile;
+   StringRef OutputFileName = getCompilerInstance().getFrontendOpts().OutputFile;
+   if (!OutputFileName.empty() && OutputFileName != "-") {
+     std::error_code EC;
+     OutFile.reset(new llvm::raw_fd_ostream(OutputFileName.str(), EC,
+                                            llvm::sys::fs::F_Text));
+   }
+   llvm::raw_ostream &Out = OutFile.get()? *OutFile.get() : llvm::outs();
+ 
+   Out << "Information for module file '" << getCurrentFile() << "':\n";
+   auto &FileMgr = getCompilerInstance().getFileManager();
+   auto Buffer = FileMgr.getBufferForFile(getCurrentFile());
+   StringRef Magic = (*Buffer)->getMemBufferRef().getBuffer();
+   bool IsRaw = (Magic.size() >= 4 && Magic[0] == 'C' && Magic[1] == 'P' &&
+                 Magic[2] == 'C' && Magic[3] == 'H');
+   Out << "  Module format: " << (IsRaw ? "raw" : "obj") << "\n";
+ 
+   Preprocessor &PP = getCompilerInstance().getPreprocessor();
+   DumpModuleInfoListener Listener(Out);
+   HeaderSearchOptions &HSOpts =
+       PP.getHeaderSearchInfo().getHeaderSearchOpts();
+   ASTReader::readASTFileControlBlock(
+       getCurrentFile(), FileMgr, getCompilerInstance().getPCHContainerReader(),
+       /*FindModuleFileExtensions=*/true, Listener,
+       HSOpts.ModulesValidateDiagnosticOptions);
+ }
+ 
+ //===----------------------------------------------------------------------===//
+ // Preprocessor Actions
+ //===----------------------------------------------------------------------===//
+ 
+ void DumpRawTokensAction::ExecuteAction() {
+   Preprocessor &PP = getCompilerInstance().getPreprocessor();
+   SourceManager &SM = PP.getSourceManager();
+ 
+   // Start lexing the specified input file.
+   const llvm::MemoryBuffer *FromFile = SM.getBuffer(SM.getMainFileID());
+   Lexer RawLex(SM.getMainFileID(), FromFile, SM, PP.getLangOpts());
+   RawLex.SetKeepWhitespaceMode(true);
+ 
+   Token RawTok;
+   RawLex.LexFromRawLexer(RawTok);
+   while (RawTok.isNot(tok::eof)) {
+     PP.DumpToken(RawTok, true);
+     llvm::errs() << "\n";
+     RawLex.LexFromRawLexer(RawTok);
+   }
+ }
+ 
+ void DumpTokensAction::ExecuteAction() {
+   Preprocessor &PP = getCompilerInstance().getPreprocessor();
+   // Start preprocessing the specified input file.
+   Token Tok;
+   PP.EnterMainSourceFile();
+   do {
+     PP.Lex(Tok);
+     PP.DumpToken(Tok, true);
+     llvm::errs() << "\n";
+   } while (Tok.isNot(tok::eof));
+ }
+ 
+ void GeneratePTHAction::ExecuteAction() {
+   CompilerInstance &CI = getCompilerInstance();
+   std::unique_ptr<raw_pwrite_stream> OS =
+       CI.createDefaultOutputFile(true, getCurrentFile());
+   if (!OS)
+     return;
+ 
+   CacheTokens(CI.getPreprocessor(), OS.get());
+ }
+ 
+ void PreprocessOnlyAction::ExecuteAction() {
+   Preprocessor &PP = getCompilerInstance().getPreprocessor();
+ 
+   // Ignore unknown pragmas.
+   PP.IgnorePragmas();
+ 
+   Token Tok;
+   // Start parsing the specified input file.
+   PP.EnterMainSourceFile();
+   do {
+     PP.Lex(Tok);
+   } while (Tok.isNot(tok::eof));
+ }
+ 
+ void PrintPreprocessedAction::ExecuteAction() {
+   CompilerInstance &CI = getCompilerInstance();
+   // Output file may need to be set to 'Binary', to avoid converting Unix style
+   // line feeds (<LF>) to Microsoft style line feeds (<CR><LF>).
+   //
+   // Look to see what type of line endings the file uses. If there's a
+   // CRLF, then we won't open the file up in binary mode. If there is
+   // just an LF or CR, then we will open the file up in binary mode.
+   // In this fashion, the output format should match the input format, unless
+   // the input format has inconsistent line endings.
+   //
+   // This should be a relatively fast operation since most files won't have
+   // all of their source code on a single line. However, that is still a 
+   // concern, so if we scan for too long, we'll just assume the file should
+   // be opened in binary mode.
+   bool BinaryMode = true;
+   bool InvalidFile = false;
+   const SourceManager& SM = CI.getSourceManager();
+   const llvm::MemoryBuffer *Buffer = SM.getBuffer(SM.getMainFileID(), 
+                                                      &InvalidFile);
+   if (!InvalidFile) {
+     const char *cur = Buffer->getBufferStart();
+     const char *end = Buffer->getBufferEnd();
+     const char *next = (cur != end) ? cur + 1 : end;
+ 
+     // Limit ourselves to only scanning 256 characters into the source
+     // file.  This is mostly a sanity check in case the file has no 
+     // newlines whatsoever.
+     if (end - cur > 256) end = cur + 256;
+ 
+     while (next < end) {
+       if (*cur == 0x0D) {  // CR
+         if (*next == 0x0A)  // CRLF
+           BinaryMode = false;
+ 
+         break;
+       } else if (*cur == 0x0A)  // LF
+         break;
+ 
+       ++cur;
+       ++next;
+     }
+   }
+ 
+   std::unique_ptr<raw_ostream> OS =
+       CI.createDefaultOutputFile(BinaryMode, getCurrentFile());
+   if (!OS) return;
+ 
+   // If we're preprocessing a module map, start by dumping the contents of the
+   // module itself before switching to the input buffer.
+   auto &Input = getCurrentInput();
+   if (Input.getKind().getFormat() == InputKind::ModuleMap) {
+     if (Input.isFile()) {
+       (*OS) << "# 1 \"";
+       OS->write_escaped(Input.getFile());
+       (*OS) << "\"\n";
+     }
+     // FIXME: Include additional information here so that we don't need the
+     // original source files to exist on disk.
+     getCurrentModule()->print(*OS);
+     (*OS) << "#pragma clang module contents\n";
+   }
+ 
+   DoPrintPreprocessedInput(CI.getPreprocessor(), OS.get(),
+                            CI.getPreprocessorOutputOpts());
+ }
+ 
+ void PrintPreambleAction::ExecuteAction() {
+   switch (getCurrentFileKind().getLanguage()) {
+   case InputKind::C:
+   case InputKind::CXX:
+   case InputKind::ObjC:
+   case InputKind::ObjCXX:
+   case InputKind::OpenCL:
+   case InputKind::CUDA:
+     break;
+       
+   case InputKind::Unknown:
+   case InputKind::Asm:
+   case InputKind::LLVM_IR:
+   case InputKind::RenderScript:
+     // We can't do anything with these.
+     return;
+   }
+ 
+   // We don't expect to find any #include directives in a preprocessed input.
+   if (getCurrentFileKind().isPreprocessed())
+     return;
+ 
+   CompilerInstance &CI = getCompilerInstance();
+   auto Buffer = CI.getFileManager().getBufferForFile(getCurrentFile());
+   if (Buffer) {
+     unsigned Preamble =
+         Lexer::ComputePreamble((*Buffer)->getBuffer(), CI.getLangOpts()).Size;
+     llvm::outs().write((*Buffer)->getBufferStart(), Preamble);
+   }
+ }

--- a/templight_clang_patch_with_context.diff
+++ b/templight_clang_patch_with_context.diff
@@ -1,8 +1,8 @@
 diff --git a/include/clang/Driver/CC1Options.td b/include/clang/Driver/CC1Options.td
-index f867218..a84c0c8 100644
+index 97c996d..e0b6e6f 100644
 --- a/include/clang/Driver/CC1Options.td
 +++ b/include/clang/Driver/CC1Options.td
-@@ -1,843 +1,845 @@
+@@ -1,841 +1,843 @@
  //===--- CC1Options.td - Options for clang -cc1 ---------------------------===//
  //
  //                     The LLVM Compiler Infrastructure
@@ -714,8 +714,6 @@ index f867218..a84c0c8 100644
    HelpText<"Allow Objective-C array and dictionary subscripting in legacy runtime">;
  def vtordisp_mode_EQ : Joined<["-"], "vtordisp-mode=">,
    HelpText<"Control vtordisp placement on win32 targets">;
- def fno_rtti_data : Flag<["-"], "fno-rtti-data">,
-   HelpText<"Control emission of RTTI data">;
  def fnative_half_type: Flag<["-"], "fnative-half-type">,
    HelpText<"Use the native half type for __fp16 instead of promoting to float">;
  def fnative_half_arguments_and_returns : Flag<["-"], "fnative-half-arguments-and-returns">,
@@ -1215,10 +1213,10 @@ index c609500..af3a22b 100644
  
  #endif
 diff --git a/lib/Frontend/CompilerInvocation.cpp b/lib/Frontend/CompilerInvocation.cpp
-index 3bdc116..571928a 100644
+index 23f3c8f..2259c94 100644
 --- a/lib/Frontend/CompilerInvocation.cpp
 +++ b/lib/Frontend/CompilerInvocation.cpp
-@@ -1,3054 +1,3055 @@
+@@ -1,3070 +1,3071 @@
  //===--- CompilerInvocation.cpp -------------------------------------------===//
  //
  //                     The LLVM Compiler Infrastructure
@@ -1766,6 +1764,7 @@ index 3bdc116..571928a 100644
    Opts.DebugTypeExtRefs = Args.hasArg(OPT_dwarf_ext_refs);
    Opts.DebugExplicitImport = Args.hasArg(OPT_dwarf_explicit_import);
    Opts.DebugFwdTemplateParams = Args.hasArg(OPT_debug_forward_template_params);
+   Opts.EmbedSource = Args.hasArg(OPT_gembed_source);
  
    for (const auto &Arg : Args.getAllArgValues(OPT_fdebug_prefix_map_EQ))
      Opts.DebugPrefixMap.insert(StringRef(Arg).split('='));
@@ -1860,6 +1859,8 @@ index 3bdc116..571928a 100644
    Opts.DisableFree = Args.hasArg(OPT_disable_free);
    Opts.DiscardValueNames = Args.hasArg(OPT_discard_value_names);
    Opts.DisableTailCalls = Args.hasArg(OPT_mdisable_tail_calls);
+   Opts.NoEscapingBlockTailCalls =
+       Args.hasArg(OPT_fno_escaping_block_tail_calls);
    Opts.FloatABI = Args.getLastArgValue(OPT_mfloat_abi);
    Opts.LessPreciseFPMAD = Args.hasArg(OPT_cl_mad_enable) ||
                            Args.hasArg(OPT_cl_unsafe_math_optimizations) ||
@@ -1880,6 +1881,8 @@ index 3bdc116..571928a 100644
    Opts.FlushDenorm = Args.hasArg(OPT_cl_denorms_are_zero);
    Opts.CorrectlyRoundedDivSqrt =
        Args.hasArg(OPT_cl_fp32_correctly_rounded_divide_sqrt);
+   Opts.UniformWGSize =
+       Args.hasArg(OPT_cl_uniform_work_group_size);
    Opts.Reciprocals = Args.getAllArgValues(OPT_mrecip_EQ);
    Opts.ReciprocalMath = Args.hasArg(OPT_freciprocal_math);
    Opts.NoTrappingMath = Args.hasArg(OPT_fno_trapping_math);
@@ -2142,6 +2145,8 @@ index 3bdc116..571928a 100644
      Opts.StackProbeSize = StackProbeSize;
    }
  
+   Opts.NoStackArgProbe = Args.hasArg(OPT_mno_stack_arg_probe);
+ 
    if (Arg *A = Args.getLastArg(OPT_fobjc_dispatch_method_EQ)) {
      StringRef Name = A->getValue();
      unsigned Method = llvm::StringSwitch<unsigned>(Name)
@@ -2158,8 +2163,12 @@ index 3bdc116..571928a 100644
      }
    }
  
-   Opts.EmulatedTLS =
-       Args.hasFlag(OPT_femulated_tls, OPT_fno_emulated_tls, false);
+   if (Args.getLastArg(OPT_femulated_tls) ||
+       Args.getLastArg(OPT_fno_emulated_tls)) {
+     Opts.ExplicitEmulatedTLS = true;
+     Opts.EmulatedTLS =
+         Args.hasFlag(OPT_femulated_tls, OPT_fno_emulated_tls, false);
+   }
  
    if (Arg *A = Args.getLastArg(OPT_ftlsmodel_EQ)) {
      StringRef Name = A->getValue();
@@ -2262,8 +2271,8 @@ index 3bdc116..571928a 100644
                        Args.getAllArgValues(OPT_fsanitize_trap_EQ), Diags,
                        Opts.SanitizeTrap);
  
-   Opts.CudaGpuBinaryFileNames =
-       Args.getAllArgValues(OPT_fcuda_include_gpubinary);
+   Opts.CudaGpuBinaryFileName =
+       Args.getLastArgValue(OPT_fcuda_include_gpubinary);
  
    Opts.Backchain = Args.hasArg(OPT_mbackchain);
  
@@ -3743,6 +3752,10 @@ index 3bdc116..571928a 100644
            << Opts.OMPHostIRFile;
    }
  
+   // set CUDA mode for OpenMP target NVPTX if specified in options
+   Opts.OpenMPCUDAMode = Opts.OpenMPIsDevice && T.isNVPTX() &&
+                         Args.hasArg(options::OPT_fopenmp_cuda_mode);
+ 
    // Record whether the __DEPRECATED define was requested.
    Opts.Deprecated = Args.hasFlag(OPT_fdeprecated_macro,
                                   OPT_fno_deprecated_macro,
@@ -3999,6 +4012,7 @@ index 3bdc116..571928a 100644
    if (Opts.Triple.empty())
      Opts.Triple = llvm::sys::getDefaultTargetTriple();
    Opts.OpenCLExtensionsAsWritten = Args.getAllArgValues(OPT_cl_ext_EQ);
+   Opts.ForceEnableInt128 = Args.hasArg(OPT_fforce_enable_int128);
  }
  
  bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
@@ -4275,10 +4289,10 @@ index 3bdc116..571928a 100644
  }
  } // end namespace clang
 diff --git a/lib/Frontend/FrontendActions.cpp b/lib/Frontend/FrontendActions.cpp
-index 1eff566..505faf5 100644
+index 1eff566..6340a93 100644
 --- a/lib/Frontend/FrontendActions.cpp
 +++ b/lib/Frontend/FrontendActions.cpp
-@@ -1,756 +1,789 @@
+@@ -1,756 +1,802 @@
  //===--- FrontendActions.cpp ----------------------------------------------===//
  //
  //                     The LLVM Compiler Infrastructure
@@ -4569,7 +4583,7 @@ index 1eff566..505faf5 100644
    std::string Event;
    std::string DefinitionLocation;
    std::string PointOfInstantiation;
-+  std::chrono::high_resolution_clock::rep TimeStamp;
++  Optional<std::chrono::high_resolution_clock::rep> TimeStamp;
  };
  } // namespace
  
@@ -4595,29 +4609,48 @@ index 1eff566..505faf5 100644
  public:
    void initialize(const Sema &) override {}
  
-   void finalize(const Sema &) override {}
+-  void finalize(const Sema &) override {}
++  void finalize(const Sema &) override {
++    if(IsProfilingEnabled)
++      for(auto &Entry : TemplightEntries)
++        displayTemplightEntry(llvm::outs(), Entry);
++  }
  
    void atTemplateBegin(const Sema &TheSema,
                         const CodeSynthesisContext &Inst) override {
-     displayTemplightEntry<true>(llvm::outs(), TheSema, Inst);
+-    displayTemplightEntry<true>(llvm::outs(), TheSema, Inst);
++    TemplightEntry Entry = getTemplightEntry<true>(TheSema, Inst);
++
++    if(IsProfilingEnabled)
++      TemplightEntries.push_back(std::move(Entry));
++    else
++      displayTemplightEntry(llvm::outs(), Entry);
    }
  
    void atTemplateEnd(const Sema &TheSema,
                       const CodeSynthesisContext &Inst) override {
-     displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
-   }
-+  
-+  static void enableProfiling() {
-+    IsProfilingEnabled = true;
+-    displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
++    TemplightEntry Entry = getTemplightEntry<false>(TheSema, Inst);
++
++    if(IsProfilingEnabled)
++      TemplightEntries.push_back(std::move(Entry));
++    else
++      displayTemplightEntry(llvm::outs(), Entry);
 +  }
-+  static bool isProfilingEnabled() {
++  
++  void enableProfiling() {
++    IsProfilingEnabled = true;
+   }
++  bool isProfilingEnabled() {
 +    return IsProfilingEnabled;
 +  }
++
 +  static const std::chrono::time_point<std::chrono::high_resolution_clock> start;
  
  private:
 +
-+  static bool IsProfilingEnabled;
++  bool IsProfilingEnabled = false;
++  std::vector<TemplightEntry> TemplightEntries;
 +  
    static std::string toString(CodeSynthesisContext::SynthesisKind Kind) {
      switch (Kind) {
@@ -4647,15 +4680,17 @@ index 1eff566..505faf5 100644
      return "";
    }
  
-   template <bool BeginInstantiation>
-   static void displayTemplightEntry(llvm::raw_ostream &Out, const Sema &TheSema,
-                                     const CodeSynthesisContext &Inst) {
+-  template <bool BeginInstantiation>
+-  static void displayTemplightEntry(llvm::raw_ostream &Out, const Sema &TheSema,
+-                                    const CodeSynthesisContext &Inst) {
++  void displayTemplightEntry(llvm::raw_ostream &Out, 
++                                              TemplightEntry& Entry) {
      std::string YAML;
      {
        llvm::raw_string_ostream OS(YAML);
        llvm::yaml::Output YO(OS);
-       TemplightEntry Entry =
-           getTemplightEntry<BeginInstantiation>(TheSema, Inst);
+-      TemplightEntry Entry =
+-          getTemplightEntry<BeginInstantiation>(TheSema, Inst);
        llvm::yaml::EmptyContext Context;
        llvm::yaml::yamlize(YO, Entry, true, Context);
      }
@@ -4663,7 +4698,8 @@ index 1eff566..505faf5 100644
    }
  
    template <bool BeginInstantiation>
-   static TemplightEntry getTemplightEntry(const Sema &TheSema,
+-  static TemplightEntry getTemplightEntry(const Sema &TheSema,
++  TemplightEntry getTemplightEntry(const Sema &TheSema,
                                            const CodeSynthesisContext &Inst) {
      TemplightEntry Entry;
 +    if (IsProfilingEnabled){
@@ -4693,7 +4729,6 @@ index 1eff566..505faf5 100644
    }
  };
 +
-+bool DefaultTemplateInstCallback::IsProfilingEnabled = false;
 +const std::chrono::time_point<std::chrono::high_resolution_clock> 
 +  DefaultTemplateInstCallback::start = std::chrono::high_resolution_clock::now();
 +
@@ -4708,8 +4743,8 @@ index 1eff566..505faf5 100644
 +  io.mapRequired("event", fields.Event);
 +  io.mapRequired("orig", fields.DefinitionLocation);
 +  io.mapRequired("poi", fields.PointOfInstantiation);
-+  if(DefaultTemplateInstCallback::isProfilingEnabled())
-+    io.mapRequired("stamp", fields.TimeStamp);
++  if(fields.TimeStamp)
++    io.mapRequired("stamp", fields.TimeStamp.getValue());
 +}
 +} // namespace yaml
 +} // namespace llvm
@@ -4728,10 +4763,13 @@ index 1eff566..505faf5 100644
    // here so the source manager would be initialized.
    EnsureSemaIsCreated(CI, *this);
  
-   CI.getSema().TemplateInstCallbacks.push_back(
-       llvm::make_unique<DefaultTemplateInstCallback>());
+-  CI.getSema().TemplateInstCallbacks.push_back(
+-      llvm::make_unique<DefaultTemplateInstCallback>());
++  auto D = llvm::make_unique<DefaultTemplateInstCallback>();
 +  if(CI.getFrontendOpts().TemplightProfile)
-+    DefaultTemplateInstCallback::enableProfiling();
++    D->enableProfiling();
++  
++  CI.getSema().TemplateInstCallbacks.push_back(std::move(D));
    ASTFrontendAction::ExecuteAction();
  }
  
@@ -5075,3 +5113,46 @@ index 1eff566..505faf5 100644
      llvm::outs().write((*Buffer)->getBufferStart(), Preamble);
    }
  }
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 9f76d36..541a2b7 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -1,37 +1,38 @@
+ create_subdirectory_options(CLANG TOOL)
+ 
+ add_clang_subdirectory(diagtool)
+ add_clang_subdirectory(driver)
+ add_clang_subdirectory(clang-diff)
+ add_clang_subdirectory(clang-format)
+ add_clang_subdirectory(clang-format-vs)
+ add_clang_subdirectory(clang-fuzzer)
+ add_clang_subdirectory(clang-import-test)
+ add_clang_subdirectory(clang-offload-bundler)
+ 
+ add_clang_subdirectory(c-index-test)
+ 
+ add_clang_subdirectory(clang-rename)
+ add_clang_subdirectory(clang-refactor)
+ 
+ if(CLANG_ENABLE_ARCMT)
+   add_clang_subdirectory(arcmt-test)
+   add_clang_subdirectory(c-arcmt-test)
+ endif()
+ 
+ if(CLANG_ENABLE_STATIC_ANALYZER)
+   add_clang_subdirectory(clang-check)
+   add_clang_subdirectory(clang-func-mapping)
+   add_clang_subdirectory(scan-build)
+   add_clang_subdirectory(scan-view)
+ endif()
+ 
+ # We support checking out the clang-tools-extra repository into the 'extra'
+ # subdirectory. It contains tools developed as part of the Clang/LLVM project
+ # on top of the Clang tooling platform. We keep them in a separate repository
+ # to keep the primary Clang repository small and focused.
+ # It also may be included by LLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR.
+ add_llvm_external_project(clang-tools-extra extra)
+ 
+ # libclang may require clang-tidy in clang-tools-extra.
+ add_clang_subdirectory(libclang)
++add_clang_subdirectory(templight)

--- a/templight_clang_patch_with_context.diff
+++ b/templight_clang_patch_with_context.diff
@@ -4289,7 +4289,7 @@ index 23f3c8f..2259c94 100644
  }
  } // end namespace clang
 diff --git a/lib/Frontend/FrontendActions.cpp b/lib/Frontend/FrontendActions.cpp
-index 1eff566..6340a93 100644
+index 1eff566..1656095 100644
 --- a/lib/Frontend/FrontendActions.cpp
 +++ b/lib/Frontend/FrontendActions.cpp
 @@ -1,756 +1,802 @@
@@ -4611,8 +4611,8 @@ index 1eff566..6340a93 100644
  
 -  void finalize(const Sema &) override {}
 +  void finalize(const Sema &) override {
-+    if(IsProfilingEnabled)
-+      for(auto &Entry : TemplightEntries)
++    if(isProfilingEnabled())
++      for(auto &Entry : *TemplightEntries)
 +        displayTemplightEntry(llvm::outs(), Entry);
 +  }
  
@@ -4621,8 +4621,8 @@ index 1eff566..6340a93 100644
 -    displayTemplightEntry<true>(llvm::outs(), TheSema, Inst);
 +    TemplightEntry Entry = getTemplightEntry<true>(TheSema, Inst);
 +
-+    if(IsProfilingEnabled)
-+      TemplightEntries.push_back(std::move(Entry));
++    if(isProfilingEnabled())
++      TemplightEntries->push_back(std::move(Entry));
 +    else
 +      displayTemplightEntry(llvm::outs(), Entry);
    }
@@ -4632,25 +4632,25 @@ index 1eff566..6340a93 100644
 -    displayTemplightEntry<false>(llvm::outs(), TheSema, Inst);
 +    TemplightEntry Entry = getTemplightEntry<false>(TheSema, Inst);
 +
-+    if(IsProfilingEnabled)
-+      TemplightEntries.push_back(std::move(Entry));
++    if(isProfilingEnabled())
++      TemplightEntries->push_back(std::move(Entry));
 +    else
 +      displayTemplightEntry(llvm::outs(), Entry);
 +  }
 +  
 +  void enableProfiling() {
-+    IsProfilingEnabled = true;
++    TemplightEntries = std::vector<TemplightEntry>();
    }
++  
 +  bool isProfilingEnabled() {
-+    return IsProfilingEnabled;
++    return TemplightEntries.hasValue();
 +  }
 +
 +  static const std::chrono::time_point<std::chrono::high_resolution_clock> start;
  
  private:
 +
-+  bool IsProfilingEnabled = false;
-+  std::vector<TemplightEntry> TemplightEntries;
++  Optional<std::vector<TemplightEntry>> TemplightEntries = None;
 +  
    static std::string toString(CodeSynthesisContext::SynthesisKind Kind) {
      switch (Kind) {
@@ -4702,7 +4702,7 @@ index 1eff566..6340a93 100644
 +  TemplightEntry getTemplightEntry(const Sema &TheSema,
                                            const CodeSynthesisContext &Inst) {
      TemplightEntry Entry;
-+    if (IsProfilingEnabled){
++    if (isProfilingEnabled()){
 +      auto end = std::chrono::high_resolution_clock::now();
 +      Entry.TimeStamp = std::chrono::nanoseconds(end-start).count();
 +    }
@@ -5113,46 +5113,3 @@ index 1eff566..6340a93 100644
      llvm::outs().write((*Buffer)->getBufferStart(), Preamble);
    }
  }
-diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
-index 9f76d36..541a2b7 100644
---- a/tools/CMakeLists.txt
-+++ b/tools/CMakeLists.txt
-@@ -1,37 +1,38 @@
- create_subdirectory_options(CLANG TOOL)
- 
- add_clang_subdirectory(diagtool)
- add_clang_subdirectory(driver)
- add_clang_subdirectory(clang-diff)
- add_clang_subdirectory(clang-format)
- add_clang_subdirectory(clang-format-vs)
- add_clang_subdirectory(clang-fuzzer)
- add_clang_subdirectory(clang-import-test)
- add_clang_subdirectory(clang-offload-bundler)
- 
- add_clang_subdirectory(c-index-test)
- 
- add_clang_subdirectory(clang-rename)
- add_clang_subdirectory(clang-refactor)
- 
- if(CLANG_ENABLE_ARCMT)
-   add_clang_subdirectory(arcmt-test)
-   add_clang_subdirectory(c-arcmt-test)
- endif()
- 
- if(CLANG_ENABLE_STATIC_ANALYZER)
-   add_clang_subdirectory(clang-check)
-   add_clang_subdirectory(clang-func-mapping)
-   add_clang_subdirectory(scan-build)
-   add_clang_subdirectory(scan-view)
- endif()
- 
- # We support checking out the clang-tools-extra repository into the 'extra'
- # subdirectory. It contains tools developed as part of the Clang/LLVM project
- # on top of the Clang tooling platform. We keep them in a separate repository
- # to keep the primary Clang repository small and focused.
- # It also may be included by LLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR.
- add_llvm_external_project(clang-tools-extra extra)
- 
- # libclang may require clang-tidy in clang-tools-extra.
- add_clang_subdirectory(libclang)
-+add_clang_subdirectory(templight)

--- a/utils/create_patch.sh
+++ b/utils/create_patch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script can be used for re-creating the patch. It assumes, that the source
+# code has been checked out as part of the llvm/clang source tree according to
+# the tutorial found in README.md of this repository.
+
+export LANG=C
+export LC_MESSAGES=C
+export LC_COLLATE=C
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+cd "${SCRIPTPATH}/../../.."
+
+git diff > tools/templight/templight_clang_patch.diff
+git diff -U999999 > tools/templight/templight_clang_patch_with_context.diff


### PR DESCRIPTION
Note that `utils/create_patch.sh` now uses `git` instead of `svn`.

LLVM git: 930bcc9bdfb9542a292c3de874d7e6ba1464cfe0
LLVM svn: https://llvm.org/svn/llvm-project/llvm/trunk@325569
clang git: 6eb4766e65557933c30152738c47e6ff34a1d216
clang svn: https://llvm.org/svn/llvm-project/cfe/trunk@325571