### PR TITLE
Fixed linker errors when building with ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,13 @@ add_clang_executable(templight
 
 target_link_libraries(templight
   PRIVATE
+  clangAST
   clangBasic
+  clangDriver
   clangFrontend
   clangFrontendTool
+  clangLex
+  clangSema
   )
 
 set_target_properties(templight PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})


### PR DESCRIPTION
With the following cmake command, I got a lot of "undefined symbol" linker errors:
```bash
cmake -G "Ninja" \
  -DBUILD_SHARED_LIBS=ON \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -DLLVM_ENABLE_ASSERTIONS=ON \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DLLVM_USE_LINKER=lld \
  -DLLVM_TARGETS_TO_BUILD=X86 \
  ../llvm/
```

This patch adds the necessary libraries to `target_link_libraries`. Did anyone have similar issues when using ninja?