### PR TITLE
Fixed a linking error and a warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(templight
   clangFrontendTool
   clangLex
   clangSema
+  clangSerialization
   )
 
 set_target_properties(templight PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})

--- a/TemplightProtobufWriter.cpp
+++ b/TemplightProtobufWriter.cpp
@@ -239,6 +239,7 @@ std::string TemplightProtobufWriter::printTemplateName(const std::string& Name) 
         break;
       } // else, go to case 0:
     }
+    LLVM_FALLTHROUGH;
     case 0:
       // optional string name = 1;
       llvm::protobuf::saveString(OS_inner, 1, Name); // name


### PR DESCRIPTION
Title says it all.

Link error:
```
ld.lld: error: undefined symbol: clang::PCHContainerOperations::PCHContainerOperations()
>>> referenced by new_allocator.h:120 (/usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/ext/new_allocator.h:120)
>>>               tools/clang/tools/templight/CMakeFiles/templight.dir/templight_driver.cpp.o:(main)

ld.lld: error: undefined symbol: clang::PCHContainerOperations::PCHContainerOperations()
>>> referenced by new_allocator.h:120 (/usr/lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/ext/new_allocator.h:120)
>>>               tools/clang/tools/templight/CMakeFiles/templight.dir/templight_driver.cpp.o:(main)
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```

The warning:

```
/home/eumakri/Documents/templight-master/llvm/tools/clang/tools/templight/TemplightProtobufWriter.cpp:242:5: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]
    case 0:
    ^
/home/eumakri/Documents/templight-master/llvm/tools/clang/tools/templight/TemplightProtobufWriter.cpp:242:5: note: insert 'LLVM_FALLTHROUGH;' to silence this warning
    case 0:
    ^
    LLVM_FALLTHROUGH; 
/home/eumakri/Documents/templight-master/llvm/tools/clang/tools/templight/TemplightProtobufWriter.cpp:242:5: note: insert 'break;' to avoid fall-through
    case 0:
    ^
    break; 
1 warning generated.
```