### PR TITLE
Added lit and unit test infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,3 +113,11 @@ if(WITH_POLLY AND LINK_POLLY_INTO_TOOLS)
     endforeach(lib)
   endif(POLLY_LINK_LIBS)
 endif(WITH_POLLY AND LINK_POLLY_INTO_TOOLS)
+
+set(TEMPLIGHT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(TEMPLIGHT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+if(CLANG_INCLUDE_TESTS)
+add_subdirectory(test)
+add_subdirectory(unittests)
+endif()

--- a/lib/TemplightAction.cpp
+++ b/lib/TemplightAction.cpp
@@ -139,8 +139,8 @@ bool TemplightAction::hasCodeCompletionSupport() const {
 }
 
 TemplightAction::TemplightAction(std::unique_ptr<FrontendAction> WrappedAction) :
-    WrapperFrontendAction(std::move(WrappedAction)) {
-
-}
+    WrapperFrontendAction(std::move(WrappedAction)), InstProfiler(false),
+    OutputToStdOut(false), MemoryProfile(false), OutputInSafeMode(false),
+    IgnoreSystemInst(false), InteractiveDebug(false) {}
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Test runner infrastructure for Templight. This configures the Clang
+# test trees for use by Lit, and delegates to LLVM's lit test handlers.
+
+set(TEMPLIGHT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+set(TEMPLIGHT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/..")
+
+if (CMAKE_CFG_INTDIR STREQUAL ".")
+  set(LLVM_BUILD_MODE ".")
+else ()
+  set(LLVM_BUILD_MODE "%(build_mode)s")
+endif ()
+
+string(REPLACE ${CMAKE_CFG_INTDIR} ${LLVM_BUILD_MODE} TEMPLIGHT_DIR ${LLVM_RUNTIME_OUTPUT_INTDIR})
+
+set(TEMPLIGHT_TEST_DEPS
+  ${CLANG_TEST_DEPS}
+  TemplightUnitTests
+  templight
+  llvm-config
+  FileCheck
+  count
+  not
+)
+
+set(TEMPLIGHT_TEST_EXTRA_ARGS "")
+
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
+  ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
+  )
+
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg.py
+  MAIN_CONFIG
+  ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.cfg.py
+  )
+
+add_lit_testsuite(check-templight "Running Templight regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${TEMPLIGHT_TEST_DEPS}
+  ARGS ${TEMPLIGHT_TEST_EXTRA_ARGS}
+  )
+
+set_target_properties(check-templight PROPERTIES FOLDER "Templight tests")

--- a/test/Unit/lit.cfg.py
+++ b/test/Unit/lit.cfg.py
@@ -1,0 +1,24 @@
+# -*- Python -*-
+
+# Configuration file for the 'lit' test runner.
+
+import os
+import platform
+import subprocess
+
+import lit.formats
+import lit.util
+
+# name: The name of this test suite.
+config.name = 'Templight-Unit'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = []
+
+# test_source_root: The root path where tests are located.
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.templight_obj_root, 'unittests')
+config.test_source_root = config.test_exec_root
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.GoogleTest('.', 'Tests')

--- a/test/Unit/lit.site.cfg.py.in
+++ b/test/Unit/lit.site.cfg.py.in
@@ -1,0 +1,31 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_libs_dir = "@LLVM_LIBS_DIR@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.clang_obj_root = "@CLANG_BINARY_DIR@"
+config.enable_shared = @ENABLE_SHARED@
+config.shlibdir = "@SHLIBDIR@"
+config.target_triple = "@TARGET_TRIPLE@"
+
+config.templight_obj_root = "@TEMPLIGHT_BINARY_DIR@"
+config.templight_src_root = "@TEMPLIGHT_SOURCE_DIR@"
+
+# Support substitution of the tools_dir, libs_dirs, and build_mode with user
+# parameters. This is used when we can't determine the tool dir at
+# configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_libs_dir = config.llvm_libs_dir % lit_config.params
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@TEMPLIGHT_SOURCE_DIR@/test/Unit/lit.cfg.py")

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1,0 +1,40 @@
+# -*- Python -*-
+
+import os
+import platform
+import re
+import subprocess
+import tempfile
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = 'Templight'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.c', '.cpp', '.cppm', '.m', '.mm', '.cu',
+                   '.ll', '.cl', '.s', '.S', '.modulemap', '.test', '.rs']
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ['Inputs', 'CMakeLists.txt']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.templight_obj_root, 'test')
+
+llvm_config.use_default_substitutions()
+
+llvm_config.use_clang()
+
+config.substitutions.append(('%PATH%', config.environment['PATH']))
+
+config.substitutions.append(('%templight_cc1', 'templight -cc1'))

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -1,0 +1,46 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_libs_dir = "@LLVM_LIBS_DIR@"
+config.llvm_shlib_dir = "@SHLIBDIR@"
+config.llvm_plugin_ext = "@LLVM_PLUGIN_EXT@"
+
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
+
+config.clang_obj_root = "@CLANG_BINARY_DIR@"
+config.clang_src_dir = "@CLANG_SOURCE_DIR@"
+config.clang_tools_dir = "@CLANG_TOOLS_DIR@"
+
+config.templight_obj_root = "@TEMPLIGHT_BINARY_DIR@"
+config.templight_src_root = "@TEMPLIGHT_SOURCE_DIR@"
+
+config.host_triple = "@LLVM_HOST_TRIPLE@"
+config.target_triple = "@TARGET_TRIPLE@"
+config.host_cxx = "@CMAKE_CXX_COMPILER@"
+config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
+config.clang_default_cxx_stdlib = "@CLANG_DEFAULT_CXX_STDLIB@"
+config.host_arch = "@HOST_ARCH@"
+config.python_executable = "@PYTHON_EXECUTABLE@"
+config.use_z3_solver = lit_config.params.get('USE_Z3_SOLVER', "@USE_Z3_SOLVER@")
+
+# Support substitution of the tools and libs dirs with user parameters. This is
+# used when we can't determine the tool dir at configuration time.
+try:
+    config.clang_tools_dir = config.clang_tools_dir % lit_config.params
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_shlib_dir = config.llvm_shlib_dir % lit_config.params
+    config.llvm_libs_dir = config.llvm_libs_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@TEMPLIGHT_SOURCE_DIR@/test/lit.cfg")

--- a/test/templight-driver-flag.cpp
+++ b/test/templight-driver-flag.cpp
@@ -1,0 +1,7 @@
+// RUN: rm -f %t.trace.pbf
+
+// RUN: %templight_cc1 %s -Xtemplight -profiler \
+// RUN:   -Xtemplight -output=%t.trace.pbf
+
+// grep the filename in the output trace file. That shouldn't be mangled.
+// RUN: grep "%s" %t.trace.pbf

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_custom_target(TemplightUnitTests)
+set_target_properties(TemplightUnitTests PROPERTIES FOLDER "Templight Unit Tests")
+
+function(add_templight_unittest test_dirname)
+  add_unittest(TemplightUnitTests ${test_dirname} ${ARGN})
+endfunction()
+
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+add_templight_unittest(TemplightTests
+  TemplightActionTest.cpp
+  )
+
+target_link_libraries(TemplightTests
+  PRIVATE
+  clangBasic
+  clangFrontend
+  clangSerialization
+  clangTemplight
+  clangTooling
+  )

--- a/unittests/TemplightActionTest.cpp
+++ b/unittests/TemplightActionTest.cpp
@@ -1,0 +1,23 @@
+//===- TemplightActionTest.cpp ---------------------*- C++ -*--------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TemplightAction.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Tooling/Tooling.h"
+#include "llvm/ADT/StringRef.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+
+TEST(TemplightActionTest, SimpleInvocation) {
+  EXPECT_TRUE(tooling::runToolOnCode(
+      new TemplightAction{llvm::make_unique<TemplightDumpAction>()},
+      "void f() {;}"));
+}


### PR DESCRIPTION
The two new directories, `test/` and `unittests/` houses LLVM-like
regression and unit tests, both of which can be run under the new cmake
target check-templight.

You can test the entire templight project with the check-templight and check-clang-templight targets, as the latter checks the test files within clang.

What I'll do going forward:
```
ninja -C ../build check-templight check-clang-templight
```

Please, if you could, test this out before merging. llvm-lit likes to break on random platforms for random reasons, and I don't have the resources to check them all.