### PR TITLE
Applied clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/include/PrintableTemplightEntries.h
+++ b/include/PrintableTemplightEntries.h
@@ -1,4 +1,4 @@
-//===- PrintableTemplightEntries.h ------ Clang Templight Printable Entries -*- C++ -*-===//
+//===- PrintableTemplightEntries.h -------------------*- C++ -*------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -10,11 +10,11 @@
 #ifndef LLVM_CLANG_PRINTABLE_TEMPLIGHT_ENTRIES_H
 #define LLVM_CLANG_PRINTABLE_TEMPLIGHT_ENTRIES_H
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace llvm {
-  class raw_ostream;
+class raw_ostream;
 }
 
 namespace clang {
@@ -37,27 +37,21 @@ struct PrintableTemplightEntryEnd {
   std::uint64_t MemoryUsage;
 };
 
-
 class TemplightWriter {
 public:
-  
-  TemplightWriter(llvm::raw_ostream& aOS) : OutputOS(aOS) { };
-  virtual ~TemplightWriter() { };
-  
-  virtual void initialize(const std::string& aSourceName = "") = 0;
+  TemplightWriter(llvm::raw_ostream &aOS) : OutputOS(aOS){};
+  virtual ~TemplightWriter(){};
+
+  virtual void initialize(const std::string &aSourceName = "") = 0;
   virtual void finalize() = 0;
-  
-  virtual void printEntry(const PrintableTemplightEntryBegin& aEntry) = 0;
-  virtual void printEntry(const PrintableTemplightEntryEnd& aEntry) = 0;
-  
+
+  virtual void printEntry(const PrintableTemplightEntryBegin &aEntry) = 0;
+  virtual void printEntry(const PrintableTemplightEntryEnd &aEntry) = 0;
+
 protected:
-  llvm::raw_ostream& OutputOS;
+  llvm::raw_ostream &OutputOS;
 };
 
-
-}
+} // namespace clang
 
 #endif
-
-
-

--- a/include/TemplightAction.h
+++ b/include/TemplightAction.h
@@ -20,8 +20,8 @@ namespace clang {
 
 class TemplightAction : public WrapperFrontendAction {
 protected:
-  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
-                                                        StringRef InFile) override;
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(CompilerInstance &CI, StringRef InFile) override;
   bool BeginInvocation(CompilerInstance &CI) override;
   bool BeginSourceFileAction(CompilerInstance &CI) override;
   void ExecuteAction() override;
@@ -39,12 +39,11 @@ public:
   bool hasIRSupport() const override;
   bool hasCodeCompletionSupport() const override;
 
-  static std::string CreateOutputFilename(
-    CompilerInstance *CI,
-    const std::string& OptOutputName,
-    bool OptInstProfiler,
-    bool OptOutputToStdOut,
-    bool OptMemoryProfile);
+  static std::string CreateOutputFilename(CompilerInstance *CI,
+                                          const std::string &OptOutputName,
+                                          bool OptInstProfiler,
+                                          bool OptOutputToStdOut,
+                                          bool OptMemoryProfile);
 
   unsigned InstProfiler : 1;
   unsigned OutputToStdOut : 1;
@@ -56,9 +55,9 @@ public:
   std::string BlackListFilename;
 
 private:
-  void EnsureHasSema(CompilerInstance& CI);
+  void EnsureHasSema(CompilerInstance &CI);
 };
 
-}
+} // namespace clang
 
 #endif

--- a/include/TemplightDebugger.h
+++ b/include/TemplightDebugger.h
@@ -1,4 +1,4 @@
-//===- TemplightDebugger.h ------ Clang Templight Debugger -*- C++ -*-===//
+//===- TemplightDebugger.h ------ Clang Templight Debugger -*- C++ -*------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -17,46 +17,35 @@
 
 namespace clang {
 
-
 class TemplightDebugger : public TemplateInstantiationCallback {
 public:
-  
   class InteractiveAgent; // forward-decl.
-  
+
   void initialize(const Sema &TheSema) override;
   void finalize(const Sema &TheSema) override;
-  void atTemplateBegin(const Sema &TheSema, const Sema::CodeSynthesisContext& Inst) override;
-  void atTemplateEnd(const Sema &TheSema, const Sema::CodeSynthesisContext& Inst) override;
-  
+  void atTemplateBegin(const Sema &TheSema,
+                       const Sema::CodeSynthesisContext &Inst) override;
+  void atTemplateEnd(const Sema &TheSema,
+                     const Sema::CodeSynthesisContext &Inst) override;
+
 private:
-  
   unsigned MemoryFlag : 1;
   unsigned IgnoreSystemFlag : 1;
-  
+
   std::unique_ptr<InteractiveAgent> Interactor;
-  
+
 public:
-  
   /// \brief Construct the templight debugger.
-  TemplightDebugger(const Sema &TheSema, 
-                    bool Memory = false, 
+  TemplightDebugger(const Sema &TheSema, bool Memory = false,
                     bool IgnoreSystem = false);
-  
+
   ~TemplightDebugger() override;
-  
+
   bool getMemoryFlag() const { return MemoryFlag; };
-  
-  void readBlacklists(const std::string& BLFilename);
-  
+
+  void readBlacklists(const std::string &BLFilename);
 };
 
-
-
-
-}
-
+} // namespace clang
 
 #endif
-
-
-

--- a/include/TemplightEntryPrinter.h
+++ b/include/TemplightEntryPrinter.h
@@ -1,4 +1,4 @@
-//===- TemplightProtobufReader.h ------ Clang Templight Protobuf Reader -*- C++ -*-===//
+//===- TemplightProtobufReader.h --------------------------*- C++ -*-------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -16,9 +16,8 @@
 #include <string>
 
 namespace llvm {
-  class Regex;
+class Regex;
 }
-
 
 namespace clang {
 
@@ -26,40 +25,36 @@ class TemplightWriter;
 
 class TemplightEntryPrinter {
 public:
-  
   void skipEntry();
   bool shouldIgnoreEntry(const PrintableTemplightEntryBegin &Entry);
   bool shouldIgnoreEntry(const PrintableTemplightEntryEnd &Entry);
-  
+
   void printEntry(const PrintableTemplightEntryBegin &Entry);
   void printEntry(const PrintableTemplightEntryEnd &Entry);
-  
-  void initialize(const std::string& SourceName = "");
+
+  void initialize(const std::string &SourceName = "");
   void finalize();
-  
+
   TemplightEntryPrinter(const std::string &Output);
   ~TemplightEntryPrinter();
-  
+
   bool isValid() const;
-  
-  llvm::raw_ostream* getTraceStream() const;
-  void takeWriter(TemplightWriter* aPWriter);
-  
-  void readBlacklists(const std::string& BLFilename);
-  
+
+  llvm::raw_ostream *getTraceStream() const;
+  void takeWriter(TemplightWriter *aPWriter);
+
+  void readBlacklists(const std::string &BLFilename);
+
 private:
-  
   std::size_t SkippedEndingsCount;
   std::unique_ptr<llvm::Regex> CoRegex;
   std::unique_ptr<llvm::Regex> IdRegex;
-  
-  llvm::raw_ostream* TraceOS;
-  
+
+  llvm::raw_ostream *TraceOS;
+
   std::unique_ptr<TemplightWriter> p_writer;
-  
 };
 
-}
+} // namespace clang
 
 #endif
-

--- a/include/TemplightProtobufWriter.h
+++ b/include/TemplightProtobufWriter.h
@@ -1,4 +1,4 @@
-//===- TemplightProtobufWriter.h ------ Clang Templight Protobuf Writer -*- C++ -*-===//
+//===- TemplightProtobufWriter.h --------------------*- C++ -*-------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -16,40 +16,33 @@
 #include <unordered_map>
 
 namespace llvm {
-  class raw_ostream;
+class raw_ostream;
 }
 
 namespace clang {
 
-
 class TemplightProtobufWriter : public TemplightWriter {
 private:
-  
   std::string buffer;
-  std::unordered_map< std::string, std::size_t > fileNameMap;
-  std::unordered_map< std::string, std::size_t > templateNameMap;
+  std::unordered_map<std::string, std::size_t> fileNameMap;
+  std::unordered_map<std::string, std::size_t> templateNameMap;
   int compressionMode;
-  
-  std::size_t createDictionaryEntry(const std::string& Name);
-  std::string printEntryLocation(const std::string& FileName, int Line, int Column);
-  std::string printTemplateName(const std::string& Name);
-  
+
+  std::size_t createDictionaryEntry(const std::string &Name);
+  std::string printEntryLocation(const std::string &FileName, int Line,
+                                 int Column);
+  std::string printTemplateName(const std::string &Name);
+
 public:
-  
-  TemplightProtobufWriter(llvm::raw_ostream& aOS, int aCompressLevel = 2);
-  
-  void initialize(const std::string& aSourceName = "") override;
+  TemplightProtobufWriter(llvm::raw_ostream &aOS, int aCompressLevel = 2);
+
+  void initialize(const std::string &aSourceName = "") override;
   void finalize() override;
-  
-  void printEntry(const PrintableTemplightEntryBegin& aEntry) override;
-  void printEntry(const PrintableTemplightEntryEnd& aEntry) override;
-  
+
+  void printEntry(const PrintableTemplightEntryBegin &aEntry) override;
+  void printEntry(const PrintableTemplightEntryEnd &aEntry) override;
 };
 
-
-}
+} // namespace clang
 
 #endif
-
-
-

--- a/include/TemplightTracer.h
+++ b/include/TemplightTracer.h
@@ -1,4 +1,4 @@
-//===- TemplightTracer.h ------ Clang Templight Profiler / Tracer -*- C++ -*-===//
+//===- TemplightTracer.h ---------------------------*- C++ -*--------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -17,47 +17,38 @@
 
 namespace clang {
 
-
 class TemplightTracer : public TemplateInstantiationCallback {
 public:
-  
   class TracePrinter; // forward-decl.
-  
+
   void initialize(const Sema &TheSema) override;
   void finalize(const Sema &TheSema) override;
-  void atTemplateBegin(const Sema &TheSema, const Sema::CodeSynthesisContext& Inst) override;
-  void atTemplateEnd(const Sema &TheSema, const Sema::CodeSynthesisContext& Inst) override;
-  
+  void atTemplateBegin(const Sema &TheSema,
+                       const Sema::CodeSynthesisContext &Inst) override;
+  void atTemplateEnd(const Sema &TheSema,
+                     const Sema::CodeSynthesisContext &Inst) override;
+
 private:
-  
   unsigned MemoryFlag : 1;
   unsigned SafeModeFlag : 1;
-  
+
   std::unique_ptr<TracePrinter> Printer;
-  
+
 public:
-  
   /// \brief Sets the format type of the template trace file.
   /// The argument can be xml/yaml/text
-  TemplightTracer(const Sema &TheSema, 
-                  std::string Output = "", 
-                  bool Memory = false, 
-                  bool Safemode = false,
+  TemplightTracer(const Sema &TheSema, std::string Output = "",
+                  bool Memory = false, bool Safemode = false,
                   bool IgnoreSystem = false);
-  
+
   ~TemplightTracer() override;
-  
+
   bool getMemoryFlag() const { return MemoryFlag; };
   bool getSafeModeFlag() const { return SafeModeFlag; };
-  
-  void readBlacklists(const std::string& BLFilename);
-  
+
+  void readBlacklists(const std::string &BLFilename);
 };
 
-
-}
+} // namespace clang
 
 #endif
-
-
-

--- a/include/ThinProtobuf.h
+++ b/include/ThinProtobuf.h
@@ -1,4 +1,4 @@
-//===- TemplightProtobufWriter.cpp ------ Clang Templight Protobuf Writer -*- C++ -*-===//
+//===- TemplightProtobufWriter.cpp -----------------------*- C++ -*--------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -10,12 +10,12 @@
 #ifndef LLVM_SUPPORT_THIN_PROTOBUF_H
 #define LLVM_SUPPORT_THIN_PROTOBUF_H
 
-#include <llvm/Support/raw_ostream.h>
-#include <llvm/Support/Endian.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Endian.h>
+#include <llvm/Support/raw_ostream.h>
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace llvm {
 
@@ -24,12 +24,12 @@ namespace protobuf {
 namespace {
 
 union float_to_ulong {
-  float    f;
+  float f;
   std::uint32_t ui32;
 };
 
 union double_to_ulong {
-  double   d;
+  double d;
   std::uint64_t ui64;
   std::uint32_t ui32[2];
 };
@@ -39,17 +39,17 @@ union int64_to_uint64 {
   std::uint64_t ui64;
 };
 
-}
+} // namespace
 
-inline std::uint64_t loadVarInt(StringRef& p_buf) {
+inline std::uint64_t loadVarInt(StringRef &p_buf) {
   std::uint64_t u = 0;
-  if ( p_buf.empty() )
+  if (p_buf.empty())
     return u;
   std::uint8_t shifts = 0;
-  while( p_buf.front() & 0x80 ) {
+  while (p_buf.front() & 0x80) {
     u |= (p_buf.front() & 0x7F) << shifts;
     p_buf = p_buf.drop_front(1);
-    if ( p_buf.empty() )
+    if (p_buf.empty())
       return u;
     shifts += 7;
   };
@@ -58,198 +58,205 @@ inline std::uint64_t loadVarInt(StringRef& p_buf) {
   return u;
 }
 
-template <unsigned int tag>
-struct getVarIntWire {
+template <unsigned int tag> struct getVarIntWire {
   static const unsigned int value = (tag << 3);
 };
 
-template <unsigned int tag>
-struct getIntWire {
+template <unsigned int tag> struct getIntWire {
   static const unsigned int value = (tag << 3);
 };
 
-inline std::int64_t loadSInt(StringRef& p_buf) {
+inline std::int64_t loadSInt(StringRef &p_buf) {
   std::uint64_t u = loadVarInt(p_buf);
   return (u >> 1) ^ (-static_cast<std::uint64_t>(u & 1));
 }
 
-template <unsigned int tag>
-struct getSIntWire {
+template <unsigned int tag> struct getSIntWire {
   static const unsigned int value = (tag << 3);
 };
 
-inline double loadDouble(StringRef& p_buf) {
-  if ( p_buf.size() < sizeof(double_to_ulong) ) {
+inline double loadDouble(StringRef &p_buf) {
+  if (p_buf.size() < sizeof(double_to_ulong)) {
     p_buf = p_buf.drop_front(p_buf.size());
     return double(0.0);
   };
   double_to_ulong tmp;
-  std::memcpy(reinterpret_cast<char*>(&tmp), p_buf.data(), sizeof(double_to_ulong));
+  std::memcpy(reinterpret_cast<char *>(&tmp), p_buf.data(),
+              sizeof(double_to_ulong));
   p_buf = p_buf.drop_front(sizeof(double_to_ulong));
-  tmp.ui64 = llvm::support::endian::byte_swap< std::uint64_t, llvm::support::little >(tmp.ui64);
+  tmp.ui64 =
+      llvm::support::endian::byte_swap<std::uint64_t, llvm::support::little>(
+          tmp.ui64);
   return tmp.d;
 }
 
-template <unsigned int tag>
-struct getDoubleWire {
+template <unsigned int tag> struct getDoubleWire {
   static const unsigned int value = (tag << 3) | 1;
 };
 
-inline float loadFloat(StringRef& p_buf) {
-  if ( p_buf.size() < sizeof(float_to_ulong) ) {
+inline float loadFloat(StringRef &p_buf) {
+  if (p_buf.size() < sizeof(float_to_ulong)) {
     p_buf = p_buf.drop_front(p_buf.size());
     return float(0.0);
   };
   float_to_ulong tmp;
-  std::memcpy(reinterpret_cast<char*>(&tmp), p_buf.data(), sizeof(float_to_ulong));
+  std::memcpy(reinterpret_cast<char *>(&tmp), p_buf.data(),
+              sizeof(float_to_ulong));
   p_buf = p_buf.drop_front(sizeof(float_to_ulong));
-  tmp.ui32 = llvm::support::endian::byte_swap< std::uint32_t, llvm::support::little >(tmp.ui32);
+  tmp.ui32 =
+      llvm::support::endian::byte_swap<std::uint32_t, llvm::support::little>(
+          tmp.ui32);
   return tmp.f;
 }
 
-template <unsigned int tag>
-struct getFloatWire {
+template <unsigned int tag> struct getFloatWire {
   static const unsigned int value = (tag << 3) | 5;
 };
 
-inline bool loadBool(StringRef& p_buf) {
-  if ( p_buf.empty() )
+inline bool loadBool(StringRef &p_buf) {
+  if (p_buf.empty())
     return false;
   char tmp = p_buf.front();
   p_buf = p_buf.drop_front(1);
   return tmp;
 }
 
-template <unsigned int tag>
-struct getBoolWire {
+template <unsigned int tag> struct getBoolWire {
   static const unsigned int value = (tag << 3);
 };
 
-inline std::string loadString(StringRef& p_buf) {
+inline std::string loadString(StringRef &p_buf) {
   unsigned int u = loadVarInt(p_buf);
-  if ( p_buf.size() < u ) {
+  if (p_buf.size() < u) {
     p_buf = p_buf.drop_front(p_buf.size());
     return std::string();
   };
   std::string s(p_buf.data(), u);
   p_buf = p_buf.drop_front(u);
-  return s;  //NRVO
+  return s; // NRVO
 }
 
-template <unsigned int tag>
-struct getStringWire {
+template <unsigned int tag> struct getStringWire {
   static const unsigned int value = (tag << 3) | 2;
 };
 
-inline void skipData(StringRef& p_buf, unsigned int wire) {
-  switch(wire & 0x7) {
-    case 0:
-      loadVarInt(p_buf);
-      break;
-    case 1:
-      if ( p_buf.size() < sizeof(double_to_ulong) )
-        p_buf = p_buf.drop_front(p_buf.size());
-      else
-        p_buf = p_buf.drop_front(sizeof(double_to_ulong));
-      break;
-    case 2: {
-      unsigned int u = loadVarInt(p_buf);
-      if ( p_buf.size() < u )
-        p_buf = p_buf.drop_front(p_buf.size());
-      else
-        p_buf = p_buf.drop_front(u);
-      break;
-    };
-    case 5:
-      if ( p_buf.size() < sizeof(float_to_ulong) )
-        p_buf = p_buf.drop_front(p_buf.size());
-      else
-        p_buf = p_buf.drop_front(sizeof(float_to_ulong));
-      break;
-    default:
-      break;
+inline void skipData(StringRef &p_buf, unsigned int wire) {
+  switch (wire & 0x7) {
+  case 0:
+    loadVarInt(p_buf);
+    break;
+  case 1:
+    if (p_buf.size() < sizeof(double_to_ulong))
+      p_buf = p_buf.drop_front(p_buf.size());
+    else
+      p_buf = p_buf.drop_front(sizeof(double_to_ulong));
+    break;
+  case 2: {
+    unsigned int u = loadVarInt(p_buf);
+    if (p_buf.size() < u)
+      p_buf = p_buf.drop_front(p_buf.size());
+    else
+      p_buf = p_buf.drop_front(u);
+    break;
+  };
+  case 5:
+    if (p_buf.size() < sizeof(float_to_ulong))
+      p_buf = p_buf.drop_front(p_buf.size());
+    else
+      p_buf = p_buf.drop_front(sizeof(float_to_ulong));
+    break;
+  default:
+    break;
   }
 }
 
-
-
-inline void saveVarInt(llvm::raw_ostream& OS, std::uint64_t u) {
-  std::uint8_t buf[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};  // 80-bits, supports at most a 64-bit varint.
-  std::uint8_t* pbuf = buf;
-  *pbuf = (u & 0x7F); u >>= 7;
-  while(u) {
+inline void saveVarInt(llvm::raw_ostream &OS, std::uint64_t u) {
+  std::uint8_t buf[] = {
+      0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0}; // 80-bits, supports at most a 64-bit varint.
+  std::uint8_t *pbuf = buf;
+  *pbuf = (u & 0x7F);
+  u >>= 7;
+  while (u) {
     *pbuf |= 0x80; // set first msb because there is more to come.
     pbuf++;
-    *pbuf = (u & 0x7F); u >>= 7;
+    *pbuf = (u & 0x7F);
+    u >>= 7;
   };
-  OS.write(reinterpret_cast<char*>(buf), pbuf - buf + 1);
+  OS.write(reinterpret_cast<char *>(buf), pbuf - buf + 1);
 }
 
-inline void saveVarInt(llvm::raw_ostream& OS, unsigned int tag, std::uint64_t u) {
+inline void saveVarInt(llvm::raw_ostream &OS, unsigned int tag,
+                       std::uint64_t u) {
   saveVarInt(OS, (tag << 3)); // wire-type 0: Varint.
   saveVarInt(OS, u);
 }
 
-inline void saveInt(llvm::raw_ostream& OS, unsigned int tag, std::int64_t i) {
+inline void saveInt(llvm::raw_ostream &OS, unsigned int tag, std::int64_t i) {
   saveVarInt(OS, (tag << 3)); // wire-type 0: Varint.
-  int64_to_uint64 tmp; tmp.i64 = i;
+  int64_to_uint64 tmp;
+  tmp.i64 = i;
   saveVarInt(OS, tmp.ui64);
 }
 
-inline void saveSInt(llvm::raw_ostream& OS, std::int64_t i) {
+inline void saveSInt(llvm::raw_ostream &OS, std::int64_t i) {
   // Apply the ZigZag encoding for the sign:
   saveVarInt(OS, (i << 1) ^ (i >> (sizeof(std::int64_t) * 8 - 1)));
 }
 
-inline void saveSInt(llvm::raw_ostream& OS, unsigned int tag, std::int64_t i) {
+inline void saveSInt(llvm::raw_ostream &OS, unsigned int tag, std::int64_t i) {
   saveVarInt(OS, (tag << 3)); // wire-type 0: Varint.
   saveSInt(OS, i);
 }
 
-inline void saveDouble(llvm::raw_ostream& OS, double d) {
-  double_to_ulong tmp = { d };
-  tmp.ui64 = llvm::support::endian::byte_swap< std::uint64_t, llvm::support::little >(tmp.ui64);
-  OS.write(reinterpret_cast<char*>(&tmp), sizeof(double_to_ulong));
+inline void saveDouble(llvm::raw_ostream &OS, double d) {
+  double_to_ulong tmp = {d};
+  tmp.ui64 =
+      llvm::support::endian::byte_swap<std::uint64_t, llvm::support::little>(
+          tmp.ui64);
+  OS.write(reinterpret_cast<char *>(&tmp), sizeof(double_to_ulong));
 }
 
-inline void saveDouble(llvm::raw_ostream& OS, unsigned int tag, double d) {
+inline void saveDouble(llvm::raw_ostream &OS, unsigned int tag, double d) {
   saveVarInt(OS, (tag << 3) | 1); // wire-type 1: 64-bit.
   saveDouble(OS, d);
 }
 
-inline void saveFloat(llvm::raw_ostream& OS, float d) {
-  float_to_ulong tmp = { d };
-  tmp.ui32 = llvm::support::endian::byte_swap< std::uint32_t, llvm::support::little >(tmp.ui32);
-  OS.write(reinterpret_cast<char*>(&tmp), sizeof(float_to_ulong));
+inline void saveFloat(llvm::raw_ostream &OS, float d) {
+  float_to_ulong tmp = {d};
+  tmp.ui32 =
+      llvm::support::endian::byte_swap<std::uint32_t, llvm::support::little>(
+          tmp.ui32);
+  OS.write(reinterpret_cast<char *>(&tmp), sizeof(float_to_ulong));
 }
 
-inline void saveFloat(llvm::raw_ostream& OS, unsigned int tag, float d) {
+inline void saveFloat(llvm::raw_ostream &OS, unsigned int tag, float d) {
   saveVarInt(OS, (tag << 3) | 5); // wire-type 5: 32-bit.
   saveFloat(OS, d);
 }
 
-inline void saveBool(llvm::raw_ostream& OS, bool b) {
+inline void saveBool(llvm::raw_ostream &OS, bool b) {
   char tmp = 0;
-  if(b) tmp = 1;
+  if (b)
+    tmp = 1;
   OS.write(&tmp, 1);
 }
 
-inline void saveBool(llvm::raw_ostream& OS, unsigned int tag, bool b) {
+inline void saveBool(llvm::raw_ostream &OS, unsigned int tag, bool b) {
   saveVarInt(OS, (tag << 3)); // wire-type 0: varint.
   saveBool(OS, b);
 }
 
-inline void saveString(llvm::raw_ostream& OS, StringRef s) {
+inline void saveString(llvm::raw_ostream &OS, StringRef s) {
   unsigned int u = s.size();
   saveVarInt(OS, u);
   OS.write(s.data(), u);
 }
 
-inline void saveString(llvm::raw_ostream& OS, unsigned int tag, StringRef s) {
+inline void saveString(llvm::raw_ostream &OS, unsigned int tag, StringRef s) {
   saveVarInt(OS, (tag << 3) | 2); // wire-type 2: length-delimited.
   saveString(OS, s);
 }
-
 
 } // namespace protobuf
 

--- a/lib/TemplightDebugger.cpp
+++ b/lib/TemplightDebugger.cpp
@@ -1,4 +1,4 @@
-//===- TemplightDebugger.cpp ------ Clang Templight Debugger -*- C++ -*-===//
+//===- TemplightDebugger.cpp ------------------------------*- C++ -*-------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -9,42 +9,39 @@
 
 #include "TemplightDebugger.h"
 
-#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclLookups.h"
 #include "clang/AST/DeclTemplate.h"
-#include "clang/Sema/Sema.h"
+#include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Lex/Lexer.h"
+#include "clang/Sema/Sema.h"
 
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Regex.h"
+#include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #include <cctype>
 #include <cstdio>
 #include <cstring>
 
-
 namespace clang {
 
-
 namespace {
-  
 
-const char* const SynthesisKindStrings[] = { 
-  "template instantiation",
-  "default template-argument instantiation",
-  "default function-argument instantiation",
-  "explicit template-argument substitution",
-  "deduced template-argument substitution", 
-  "prior template-argument substitution",
-  "default template-argument checking", 
-  "exception specification instantiation",
-  "memoization" };
+const char *const SynthesisKindStrings[] = {
+    "template instantiation",
+    "default template-argument instantiation",
+    "default function-argument instantiation",
+    "explicit template-argument substitution",
+    "deduced template-argument substitution",
+    "prior template-argument substitution",
+    "default template-argument checking",
+    "exception specification instantiation",
+    "memoization"};
 
 struct TemplateDebuggerEntry {
   bool IsTemplateBegin;
@@ -54,45 +51,48 @@ struct TemplateDebuggerEntry {
   int Line;
   int Column;
   std::size_t MemoryUsage;
-  
-  TemplateDebuggerEntry() : IsTemplateBegin(true), 
-    Inst(), Name(), FileName(), Line(0), Column(0), 
-    MemoryUsage(0) { };
-  
+
+  TemplateDebuggerEntry()
+      : IsTemplateBegin(true), Inst(), Name(), FileName(), Line(0), Column(0),
+        MemoryUsage(0){};
+
   TemplateDebuggerEntry(bool aIsBegin, std::size_t aMemUsage,
                         const Sema &TheSema,
-                        const Sema::CodeSynthesisContext& aInst) :
-                        IsTemplateBegin(aIsBegin), Inst(aInst), Name(), 
-                        FileName(), Line(0), Column(0), MemoryUsage(aMemUsage) { 
+                        const Sema::CodeSynthesisContext &aInst)
+      : IsTemplateBegin(aIsBegin), Inst(aInst), Name(), FileName(), Line(0),
+        Column(0), MemoryUsage(aMemUsage) {
     NamedDecl *NamedTemplate = dyn_cast_or_null<NamedDecl>(Inst.Entity);
     if (NamedTemplate) {
       llvm::raw_string_ostream OS(Name);
       NamedTemplate->getNameForDiagnostic(OS, TheSema.getLangOpts(), true);
     }
-    
-    PresumedLoc Loc = TheSema.getSourceManager().getPresumedLoc(Inst.PointOfInstantiation);
-    if(!Loc.isInvalid()) {
+
+    PresumedLoc Loc =
+        TheSema.getSourceManager().getPresumedLoc(Inst.PointOfInstantiation);
+    if (!Loc.isInvalid()) {
       FileName = Loc.getFilename();
-      Line     = Loc.getLine();
-      Column   = Loc.getColumn();
+      Line = Loc.getLine();
+      Column = Loc.getColumn();
     };
   };
 };
 
-static std::string getSrcPointer(const Sema& TheSema, SourceLocation SLoc) {
+static std::string getSrcPointer(const Sema &TheSema, SourceLocation SLoc) {
   PresumedLoc PLoc = TheSema.getSourceManager().getPresumedLoc(SLoc);
   FileID fid = TheSema.getSourceManager().getFileID(SLoc);
-  std::string SrcPointer = Lexer::getSourceText(
-    CharSourceRange::getTokenRange(
-      TheSema.getSourceManager().translateLineCol(fid, PLoc.getLine(), 1),
-      TheSema.getSourceManager().translateLineCol(fid, PLoc.getLine(), 256)
-    ), TheSema.getSourceManager(), TheSema.getLangOpts()).str();
+  std::string SrcPointer =
+      Lexer::getSourceText(CharSourceRange::getTokenRange(
+                               TheSema.getSourceManager().translateLineCol(
+                                   fid, PLoc.getLine(), 1),
+                               TheSema.getSourceManager().translateLineCol(
+                                   fid, PLoc.getLine(), 256)),
+                           TheSema.getSourceManager(), TheSema.getLangOpts())
+          .str();
   SrcPointer.push_back('\n');
-  SrcPointer.append(PLoc.getColumn()-1, ' ');
+  SrcPointer.append(PLoc.getColumn() - 1, ' ');
   SrcPointer.push_back('^');
   return SrcPointer;
 }
-
 
 template <typename OutputIter>
 void fillWithTemplateArgumentPrints(const TemplateArgument *Args,
@@ -102,9 +102,8 @@ void fillWithTemplateArgumentPrints(const TemplateArgument *Args,
   for (unsigned Arg = 0; Arg < NumArgs; ++Arg) {
     // Print the argument into a string.
     if (Args[Arg].getKind() == TemplateArgument::Pack) {
-      fillWithTemplateArgumentPrints(Args[Arg].pack_begin(), 
-                                     Args[Arg].pack_size(), 
-                                     Policy, It);
+      fillWithTemplateArgumentPrints(Args[Arg].pack_begin(),
+                                     Args[Arg].pack_size(), Policy, It);
     } else {
       std::string Buf;
       llvm::raw_string_ostream ArgOS(Buf);
@@ -114,50 +113,53 @@ void fillWithTemplateArgumentPrints(const TemplateArgument *Args,
   }
 }
 
-
-
 class TemplateArgRecorder : public RecursiveASTVisitor<TemplateArgRecorder> {
 public:
   typedef RecursiveASTVisitor<TemplateArgRecorder> Base;
-  
+
   const Sema &TheSema;
-  
+
   bool shouldVisitTemplateInstantiations() const { return false; }
-  
+
   struct PrintableQueryResult {
     std::string Name;
     std::string FileName;
     int Line;
     int Column;
     std::string SrcPointer;
-    
-    PrintableQueryResult() : Name(""), FileName("<no-file>"), Line(0), Column(0), SrcPointer("") { }
-    
-    void nullLocation(const std::string& NullName = "<no-file>") {
+
+    PrintableQueryResult()
+        : Name(""), FileName("<no-file>"), Line(0), Column(0), SrcPointer("") {}
+
+    void nullLocation(const std::string &NullName = "<no-file>") {
       FileName = NullName;
       Line = 0;
       Column = 0;
       SrcPointer = "";
     }
-    
-    void fromLocation(const Sema &TheSema, SourceLocation SLoc, const std::string& NullName = "") {
+
+    void fromLocation(const Sema &TheSema, SourceLocation SLoc,
+                      const std::string &NullName = "") {
       PresumedLoc PLoc = TheSema.getSourceManager().getPresumedLoc(SLoc);
-      
-      if(!PLoc.isInvalid()) {
+
+      if (!PLoc.isInvalid()) {
         FileName = PLoc.getFilename();
         Line = PLoc.getLine();
         Column = PLoc.getColumn();
-        
+
         FileID fid = TheSema.getSourceManager().getFileID(SLoc);
         SrcPointer = Lexer::getSourceText(
-          CharSourceRange::getTokenRange(
-            TheSema.getSourceManager().translateLineCol(fid, PLoc.getLine(), 1),
-            TheSema.getSourceManager().translateLineCol(fid, PLoc.getLine(), 256)
-          ), TheSema.getSourceManager(), TheSema.getLangOpts()).str();
+                         CharSourceRange::getTokenRange(
+                             TheSema.getSourceManager().translateLineCol(
+                                 fid, PLoc.getLine(), 1),
+                             TheSema.getSourceManager().translateLineCol(
+                                 fid, PLoc.getLine(), 256)),
+                         TheSema.getSourceManager(), TheSema.getLangOpts())
+                         .str();
         SrcPointer.push_back('\n');
-        SrcPointer.append(PLoc.getColumn()-1, ' ');
+        SrcPointer.append(PLoc.getColumn() - 1, ' ');
         SrcPointer.push_back('^');
-        
+
       } else {
         FileName = NullName;
         Line = 0;
@@ -165,47 +167,42 @@ public:
         SrcPointer = "";
       }
     }
-    
   };
-  
-  
+
   llvm::Regex QueryReg;
-  
-  enum LookupKind {
-    LookForDecl = 1,
-    LookForType = 2,
-    LookForValue = 4
-  };
-  
+
+  enum LookupKind { LookForDecl = 1, LookForType = 2, LookForValue = 4 };
+
   int QueryKind;
-  std::vector< PrintableQueryResult > QueryResults;
+  std::vector<PrintableQueryResult> QueryResults;
   // MAYBE change (or add) with Decl* or QualType, etc..
-  
-  TemplateArgRecorder(const Sema &aSema, const std::string& aReg, int aKind = LookForDecl) : 
-    TheSema(aSema), QueryReg(aReg), QueryKind(aKind) { }
-  
-  
-  void RegisterQualTypeQueryResult(PrintableQueryResult& cur_result, QualType q_type) {
-    if( QueryKind & LookForType )
+
+  TemplateArgRecorder(const Sema &aSema, const std::string &aReg,
+                      int aKind = LookForDecl)
+      : TheSema(aSema), QueryReg(aReg), QueryKind(aKind) {}
+
+  void RegisterQualTypeQueryResult(PrintableQueryResult &cur_result,
+                                   QualType q_type) {
+    if (QueryKind & LookForType)
       q_type = q_type.getCanonicalType();
     cur_result.Name += q_type.getAsString(TheSema.getLangOpts());
-    if( cur_result.Line < 1 ) {
+    if (cur_result.Line < 1) {
       SourceLocation sl;
-      if(const Type* tp = q_type.getTypePtr()) {
-        if(const CXXRecordDecl* cxx_decl = tp->getAsCXXRecordDecl()) {
+      if (const Type *tp = q_type.getTypePtr()) {
+        if (const CXXRecordDecl *cxx_decl = tp->getAsCXXRecordDecl()) {
           sl = cxx_decl->getLocation();
         }
       }
       cur_result.fromLocation(TheSema, sl, "<unknown-location>");
     }
   };
-  
+
   void LookupInParamArgLists(const TemplateParameterList *Params,
                              const TemplateArgument *Args, unsigned NumArgs) {
     for (unsigned I = 0, N = Params->size(); I != N; ++I) {
       if (I >= NumArgs)
         break;
-      
+
       std::string param_name;
       if (const IdentifierInfo *Id = Params->getParam(I)->getIdentifier()) {
         param_name = Id->getName();
@@ -214,213 +211,234 @@ public:
         OS_param << '$' << I;
         OS_param.str();
       }
-      
-      if(QueryReg.match(param_name)) {
-        
+
+      if (QueryReg.match(param_name)) {
+
         PrintableQueryResult cur_result;
-        
-        if( QueryKind & LookForDecl ) {
+
+        if (QueryKind & LookForDecl) {
           cur_result.Name = Params->getParam(I)->getName();
-          cur_result.fromLocation(TheSema, Params->getParam(I)->getLocation(), "<unknown-location>");
-        } 
-        
-        if( QueryKind != LookForDecl ) { // not (only) look-for-decl 
+          cur_result.fromLocation(TheSema, Params->getParam(I)->getLocation(),
+                                  "<unknown-location>");
+        }
+
+        if (QueryKind != LookForDecl) { // not (only) look-for-decl
           switch (Args[I].getKind()) {
-            case TemplateArgument::Null: {
-              // not much better to do.
-              if( !cur_result.Name.empty() )
+          case TemplateArgument::Null: {
+            // not much better to do.
+            if (!cur_result.Name.empty())
+              cur_result.Name += " with value ";
+            cur_result.Name += "<empty>";
+            llvm::raw_string_ostream OS_arg(cur_result.Name);
+            Args[I].print(TheSema.getPrintingPolicy(), OS_arg);
+            OS_arg.str(); // flush to string.
+            break;
+          }
+
+          case TemplateArgument::Integral: {
+            if (QueryKind & LookForValue) {
+              if (!cur_result.Name.empty())
                 cur_result.Name += " with value ";
-              cur_result.Name += "<empty>";
-              llvm::raw_string_ostream OS_arg(cur_result.Name);
-              Args[I].print(TheSema.getPrintingPolicy(), OS_arg);
-              OS_arg.str(); // flush to string.
-              break;
+              cur_result.Name += Args[I].getAsIntegral().toString(10);
             }
-            
-            case TemplateArgument::Integral: {
-              if( QueryKind & LookForValue ) {
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " with value ";
-                cur_result.Name += Args[I].getAsIntegral().toString(10);
-              } 
-              if( QueryKind & LookForType ) {
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " of type ";
-                RegisterQualTypeQueryResult(cur_result, Args[I].getIntegralType());
-              }
-              break;
+            if (QueryKind & LookForType) {
+              if (!cur_result.Name.empty())
+                cur_result.Name += " of type ";
+              RegisterQualTypeQueryResult(cur_result,
+                                          Args[I].getIntegralType());
             }
-            
-            case TemplateArgument::NullPtr: {
-              if( QueryKind & LookForValue ) {
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " with value ";
-                cur_result.Name += "nullptr";
-              }
-              if( QueryKind & LookForType ) {
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " of type ";
-                cur_result.Name += Args[I].getNullPtrType().getAsString(TheSema.getLangOpts());
-              }
-              break;
+            break;
+          }
+
+          case TemplateArgument::NullPtr: {
+            if (QueryKind & LookForValue) {
+              if (!cur_result.Name.empty())
+                cur_result.Name += " with value ";
+              cur_result.Name += "nullptr";
             }
-            
-            case TemplateArgument::Declaration: {
-              ValueDecl* vdecl = Args[I].getAsDecl();
-              if( QueryKind & LookForValue ) {
-                // Attempt to print out the constant-expression value of the declaration:
-                //  the meaningful ValueDecl would be NonTypeTemplateParmDecl, VarDecl, EnumConstantDecl, and maybe FunctionDecl
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " with value ";
-                if( VarDecl* vardecl = dyn_cast<VarDecl>(vdecl) ) {
-                  if( APValue* valptr =  vardecl->evaluateValue() ) {
-                    llvm::raw_string_ostream OS_arg(cur_result.Name);
-                    valptr->printPretty(OS_arg, TheSema.getASTContext(), vdecl->getType());
-                    OS_arg.str(); // flush to string.
-                  } else {
-                    cur_result.Name = "<could not evaluate>";
-                  }
-                } else {
+            if (QueryKind & LookForType) {
+              if (!cur_result.Name.empty())
+                cur_result.Name += " of type ";
+              cur_result.Name +=
+                  Args[I].getNullPtrType().getAsString(TheSema.getLangOpts());
+            }
+            break;
+          }
+
+          case TemplateArgument::Declaration: {
+            ValueDecl *vdecl = Args[I].getAsDecl();
+            if (QueryKind & LookForValue) {
+              // Attempt to print out the constant-expression value of the
+              // declaration:
+              //  the meaningful ValueDecl would be NonTypeTemplateParmDecl,
+              //  VarDecl, EnumConstantDecl, and maybe FunctionDecl
+              if (!cur_result.Name.empty())
+                cur_result.Name += " with value ";
+              if (VarDecl *vardecl = dyn_cast<VarDecl>(vdecl)) {
+                if (APValue *valptr = vardecl->evaluateValue()) {
                   llvm::raw_string_ostream OS_arg(cur_result.Name);
-                  vdecl->getNameForDiagnostic(OS_arg, TheSema.getLangOpts(), true);
+                  valptr->printPretty(OS_arg, TheSema.getASTContext(),
+                                      vdecl->getType());
                   OS_arg.str(); // flush to string.
-                  if( cur_result.Line < 1 )
-                    cur_result.fromLocation(TheSema, vdecl->getLocation(), "<unknown-location>");
-                }
-              }
-              if( QueryKind & LookForType ) {
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " of type ";
-                RegisterQualTypeQueryResult(cur_result, vdecl->getType());
-              }
-              break;
-            }
-            
-            case TemplateArgument::Type: {
-              if( !cur_result.Name.empty() )
-                cur_result.Name += " standing for ";
-              RegisterQualTypeQueryResult(cur_result, Args[I].getAsType());
-              break;
-            }
-            
-            case TemplateArgument::Template:
-            case TemplateArgument::TemplateExpansion: {
-              if( !cur_result.Name.empty() )
-                cur_result.Name += " standing for ";
-              llvm::raw_string_ostream OS_arg(cur_result.Name);
-              TemplateName tname = Args[I].getAsTemplateOrTemplatePattern();
-              tname.print(OS_arg, TheSema.getLangOpts());
-              OS_arg.str(); // flush to string.
-              SourceLocation sl;
-              if(TemplateDecl* tmp_decl = tname.getAsTemplateDecl()) {
-                sl = tmp_decl->getLocation();
-              }
-              if( cur_result.Line < 1 )
-                cur_result.fromLocation(TheSema, sl, "<unknown-location>");
-              break;
-            }
-            
-            case TemplateArgument::Expression: {
-              if( QueryKind & LookForValue ) {
-                // Evaluate the expression to get the value printed.
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " with value ";
-                llvm::raw_string_ostream OS_arg(cur_result.Name);
-                Args[I].getAsExpr()->printPretty(OS_arg, NULL, TheSema.getLangOpts());
-                Expr::EvalResult expr_res;
-                if( Args[I].getAsExpr()->EvaluateAsRValue(expr_res, TheSema.getASTContext()) ) {
-                  OS_arg << " == ";
-                  expr_res.Val.printPretty(OS_arg, TheSema.getASTContext(), Args[I].getAsExpr()->getType());
                 } else {
-                  OS_arg << " == <could not evaluate>";
+                  cur_result.Name = "<could not evaluate>";
                 }
+              } else {
+                llvm::raw_string_ostream OS_arg(cur_result.Name);
+                vdecl->getNameForDiagnostic(OS_arg, TheSema.getLangOpts(),
+                                            true);
                 OS_arg.str(); // flush to string.
-                if( cur_result.Line < 1 )
-                  cur_result.fromLocation(
-                    TheSema, Args[I].getAsExpr()->getExprLoc(), "<unknown-location>");
+                if (cur_result.Line < 1)
+                  cur_result.fromLocation(TheSema, vdecl->getLocation(),
+                                          "<unknown-location>");
               }
-              if( QueryKind & LookForType ) {
-                if( !cur_result.Name.empty() )
-                  cur_result.Name += " of type ";
-                RegisterQualTypeQueryResult(cur_result, Args[I].getAsExpr()->getType());
-              }
-              break;
             }
-            
-            case TemplateArgument::Pack: {
-              // not much better to do.
-              if( !cur_result.Name.empty() )
-                cur_result.Name += " standing for ";
+            if (QueryKind & LookForType) {
+              if (!cur_result.Name.empty())
+                cur_result.Name += " of type ";
+              RegisterQualTypeQueryResult(cur_result, vdecl->getType());
+            }
+            break;
+          }
+
+          case TemplateArgument::Type: {
+            if (!cur_result.Name.empty())
+              cur_result.Name += " standing for ";
+            RegisterQualTypeQueryResult(cur_result, Args[I].getAsType());
+            break;
+          }
+
+          case TemplateArgument::Template:
+          case TemplateArgument::TemplateExpansion: {
+            if (!cur_result.Name.empty())
+              cur_result.Name += " standing for ";
+            llvm::raw_string_ostream OS_arg(cur_result.Name);
+            TemplateName tname = Args[I].getAsTemplateOrTemplatePattern();
+            tname.print(OS_arg, TheSema.getLangOpts());
+            OS_arg.str(); // flush to string.
+            SourceLocation sl;
+            if (TemplateDecl *tmp_decl = tname.getAsTemplateDecl()) {
+              sl = tmp_decl->getLocation();
+            }
+            if (cur_result.Line < 1)
+              cur_result.fromLocation(TheSema, sl, "<unknown-location>");
+            break;
+          }
+
+          case TemplateArgument::Expression: {
+            if (QueryKind & LookForValue) {
+              // Evaluate the expression to get the value printed.
+              if (!cur_result.Name.empty())
+                cur_result.Name += " with value ";
               llvm::raw_string_ostream OS_arg(cur_result.Name);
-              Args[I].print(TheSema.getPrintingPolicy(), OS_arg);
+              Args[I].getAsExpr()->printPretty(OS_arg, NULL,
+                                               TheSema.getLangOpts());
+              Expr::EvalResult expr_res;
+              if (Args[I].getAsExpr()->EvaluateAsRValue(
+                      expr_res, TheSema.getASTContext())) {
+                OS_arg << " == ";
+                expr_res.Val.printPretty(OS_arg, TheSema.getASTContext(),
+                                         Args[I].getAsExpr()->getType());
+              } else {
+                OS_arg << " == <could not evaluate>";
+              }
               OS_arg.str(); // flush to string.
-              break;
+              if (cur_result.Line < 1)
+                cur_result.fromLocation(TheSema,
+                                        Args[I].getAsExpr()->getExprLoc(),
+                                        "<unknown-location>");
             }
-            
+            if (QueryKind & LookForType) {
+              if (!cur_result.Name.empty())
+                cur_result.Name += " of type ";
+              RegisterQualTypeQueryResult(cur_result,
+                                          Args[I].getAsExpr()->getType());
+            }
+            break;
+          }
+
+          case TemplateArgument::Pack: {
+            // not much better to do.
+            if (!cur_result.Name.empty())
+              cur_result.Name += " standing for ";
+            llvm::raw_string_ostream OS_arg(cur_result.Name);
+            Args[I].print(TheSema.getPrintingPolicy(), OS_arg);
+            OS_arg.str(); // flush to string.
+            break;
+          }
           }
         }
-        
+
         QueryResults.push_back(cur_result);
         return;
       }
     }
   }
-  
-  void LookupInDeclContext(DeclContext* decl, bool shouldGoUp = false) {
-    DeclContext* cur_decl = decl;
-    while(cur_decl) {
-      for(DeclContext::all_lookups_iterator it = cur_decl->lookups().begin(), 
-          it_end = cur_decl->lookups().end(); it != it_end; ++it) {
-        if(QueryReg.match(it.getLookupName().getAsString())) {
-          for(DeclContext::lookup_result::iterator ri = (*it).begin(), 
-              ri_end = (*it).end(); ri != ri_end; ++ri) {
-            NamedDecl* ndecl = *ri;
-            if(!ndecl)
+
+  void LookupInDeclContext(DeclContext *decl, bool shouldGoUp = false) {
+    DeclContext *cur_decl = decl;
+    while (cur_decl) {
+      for (DeclContext::all_lookups_iterator it = cur_decl->lookups().begin(),
+                                             it_end = cur_decl->lookups().end();
+           it != it_end; ++it) {
+        if (QueryReg.match(it.getLookupName().getAsString())) {
+          for (DeclContext::lookup_result::iterator ri = (*it).begin(),
+                                                    ri_end = (*it).end();
+               ri != ri_end; ++ri) {
+            NamedDecl *ndecl = *ri;
+            if (!ndecl)
               continue;
             PrintableQueryResult cur_result;
-            if( QueryKind & LookForDecl ) {
+            if (QueryKind & LookForDecl) {
               llvm::raw_string_ostream OS_arg(cur_result.Name);
               ndecl->getNameForDiagnostic(OS_arg, TheSema.getLangOpts(), true);
               OS_arg.str(); // flush to string.
-              cur_result.fromLocation(TheSema, ndecl->getLocation(), "<unknown-location>");
+              cur_result.fromLocation(TheSema, ndecl->getLocation(),
+                                      "<unknown-location>");
             }
-            
-            if( QueryKind != LookForDecl ) { // if not (only) look-for-decl
-              if(TypeDecl* tdecl = dyn_cast<TypeDecl>(ndecl)) {
-                if(TypedefNameDecl* utp = dyn_cast<TypedefNameDecl>(tdecl)) {
-                  if( !cur_result.Name.empty() )
+
+            if (QueryKind != LookForDecl) { // if not (only) look-for-decl
+              if (TypeDecl *tdecl = dyn_cast<TypeDecl>(ndecl)) {
+                if (TypedefNameDecl *utp = dyn_cast<TypedefNameDecl>(tdecl)) {
+                  if (!cur_result.Name.empty())
                     cur_result.Name += " alias for ";
-                  RegisterQualTypeQueryResult(cur_result, utp->getUnderlyingType());
-                } else if(const Type* tp = tdecl->getTypeForDecl()) {
-                  if( !cur_result.Name.empty() )
+                  RegisterQualTypeQueryResult(cur_result,
+                                              utp->getUnderlyingType());
+                } else if (const Type *tp = tdecl->getTypeForDecl()) {
+                  if (!cur_result.Name.empty())
                     cur_result.Name += " standing for ";
-                  RegisterQualTypeQueryResult(cur_result, tp->getCanonicalTypeInternal());
+                  RegisterQualTypeQueryResult(cur_result,
+                                              tp->getCanonicalTypeInternal());
                 }
-              } else
-              if(ValueDecl* vdecl = dyn_cast<ValueDecl>(ndecl)) {
-                if( QueryKind & LookForValue ) {
-                  // Attempt to print out the constant-expression value of the declaration:
-                  //  the meaningful ValueDecl would be NonTypeTemplateParmDecl, VarDecl, EnumConstantDecl, and maybe FunctionDecl
-                  if( !cur_result.Name.empty() )
+              } else if (ValueDecl *vdecl = dyn_cast<ValueDecl>(ndecl)) {
+                if (QueryKind & LookForValue) {
+                  // Attempt to print out the constant-expression value of the
+                  // declaration:
+                  //  the meaningful ValueDecl would be NonTypeTemplateParmDecl,
+                  //  VarDecl, EnumConstantDecl, and maybe FunctionDecl
+                  if (!cur_result.Name.empty())
                     cur_result.Name += " with value ";
-                  if( VarDecl* vardecl = dyn_cast<VarDecl>(vdecl) ) {
-                    if( APValue* valptr =  vardecl->evaluateValue() ) {
+                  if (VarDecl *vardecl = dyn_cast<VarDecl>(vdecl)) {
+                    if (APValue *valptr = vardecl->evaluateValue()) {
                       llvm::raw_string_ostream OS_arg(cur_result.Name);
-                      valptr->printPretty(OS_arg, TheSema.getASTContext(), vdecl->getType());
+                      valptr->printPretty(OS_arg, TheSema.getASTContext(),
+                                          vdecl->getType());
                       OS_arg.str(); // flush to string.
                     } else {
                       cur_result.Name = "<could not evaluate>";
                     }
                   } else {
                     llvm::raw_string_ostream OS_arg(cur_result.Name);
-                    vdecl->getNameForDiagnostic(OS_arg, TheSema.getLangOpts(), true);
+                    vdecl->getNameForDiagnostic(OS_arg, TheSema.getLangOpts(),
+                                                true);
                     OS_arg.str(); // flush to string.
-                    if( cur_result.Line < 1 )
-                      cur_result.fromLocation(TheSema, vdecl->getLocation(), "<unknown-location>");
+                    if (cur_result.Line < 1)
+                      cur_result.fromLocation(TheSema, vdecl->getLocation(),
+                                              "<unknown-location>");
                   }
-                } 
-                if( QueryKind & LookForType ) {
-                  if( !cur_result.Name.empty() )
+                }
+                if (QueryKind & LookForType) {
+                  if (!cur_result.Name.empty())
                     cur_result.Name += " of type ";
                   RegisterQualTypeQueryResult(cur_result, vdecl->getType());
                 }
@@ -431,702 +449,675 @@ public:
           return;
         }
       }
-      if(shouldGoUp) {
+      if (shouldGoUp) {
         cur_decl = cur_decl->getParent(); // recurse
       } else
         return;
     }
   }
-  
-  
-  bool TraverseActiveTempInstantiation(const Sema::CodeSynthesisContext& Inst) {
+
+  bool TraverseActiveTempInstantiation(const Sema::CodeSynthesisContext &Inst) {
     TemplateDecl *TemplatePtr = dyn_cast_or_null<TemplateDecl>(Inst.Entity);
-    if( TemplatePtr && TemplatePtr->getTemplateParameters() &&
-        ( TemplatePtr->getTemplateParameters()->size() != 0 ) && 
-        ( Inst.NumTemplateArgs != 0 ) ) {
-      LookupInParamArgLists(TemplatePtr->getTemplateParameters(), 
+    if (TemplatePtr && TemplatePtr->getTemplateParameters() &&
+        (TemplatePtr->getTemplateParameters()->size() != 0) &&
+        (Inst.NumTemplateArgs != 0)) {
+      LookupInParamArgLists(TemplatePtr->getTemplateParameters(),
                             Inst.TemplateArgs, Inst.NumTemplateArgs);
-      if( QueryResults.size() )
+      if (QueryResults.size())
         return true;
     }
-    
+
     return TraverseDecl(Inst.Entity);
   }
-  
-  
-  bool VisitFunctionDecl(FunctionDecl* decl) {
-    
+
+  bool VisitFunctionDecl(FunctionDecl *decl) {
+
     LookupInDeclContext(decl);
-    if( QueryResults.size() )
+    if (QueryResults.size())
       return true;
-    
-    if( decl->isFunctionTemplateSpecialization() ) {
-      FunctionTemplateSpecializationInfo* SpecInfo = decl->getTemplateSpecializationInfo();
-      FunctionTemplateDecl* TempDecl = SpecInfo->getTemplate();
-      if( TempDecl && TempDecl->getTemplateParameters() &&
-          ( TempDecl->getTemplateParameters()->size() != 0 ) && 
-          ( SpecInfo->TemplateArguments->size() != 0 ) ) {
-        LookupInParamArgLists(TempDecl->getTemplateParameters(), 
-                              SpecInfo->TemplateArguments->data(), SpecInfo->TemplateArguments->size());
-        if( QueryResults.size() )
+
+    if (decl->isFunctionTemplateSpecialization()) {
+      FunctionTemplateSpecializationInfo *SpecInfo =
+          decl->getTemplateSpecializationInfo();
+      FunctionTemplateDecl *TempDecl = SpecInfo->getTemplate();
+      if (TempDecl && TempDecl->getTemplateParameters() &&
+          (TempDecl->getTemplateParameters()->size() != 0) &&
+          (SpecInfo->TemplateArguments->size() != 0)) {
+        LookupInParamArgLists(TempDecl->getTemplateParameters(),
+                              SpecInfo->TemplateArguments->data(),
+                              SpecInfo->TemplateArguments->size());
+        if (QueryResults.size())
           return true;
       }
     }
-    
-    DeclContext* parent = decl->getParent();
-    if( TagDecl* t_decl = dyn_cast_or_null<TagDecl>(parent) )
+
+    DeclContext *parent = decl->getParent();
+    if (TagDecl *t_decl = dyn_cast_or_null<TagDecl>(parent))
       return getDerived().VisitTagDecl(t_decl);
     else {
       LookupInDeclContext(parent, true);
-      if( QueryResults.size() )
+      if (QueryResults.size())
         return true;
     }
-    
+
     return true;
   }
-  
-  bool VisitTagDecl(TagDecl* decl) {
-    
+
+  bool VisitTagDecl(TagDecl *decl) {
+
     LookupInDeclContext(decl);
-    if( QueryResults.size() )
+    if (QueryResults.size())
       return true;
-    
-    if( ClassTemplateSpecializationDecl* spec_decl = dyn_cast<ClassTemplateSpecializationDecl>(decl) ) {
-      ClassTemplateDecl* TempDecl = spec_decl->getSpecializedTemplate();
-      if( TempDecl && TempDecl->getTemplateParameters() &&
-          ( TempDecl->getTemplateParameters()->size() != 0 ) && 
-          ( spec_decl->getTemplateArgs().size() != 0 ) ) {
-        LookupInParamArgLists(TempDecl->getTemplateParameters(), 
-                              spec_decl->getTemplateArgs().data(), 
+
+    if (ClassTemplateSpecializationDecl *spec_decl =
+            dyn_cast<ClassTemplateSpecializationDecl>(decl)) {
+      ClassTemplateDecl *TempDecl = spec_decl->getSpecializedTemplate();
+      if (TempDecl && TempDecl->getTemplateParameters() &&
+          (TempDecl->getTemplateParameters()->size() != 0) &&
+          (spec_decl->getTemplateArgs().size() != 0)) {
+        LookupInParamArgLists(TempDecl->getTemplateParameters(),
+                              spec_decl->getTemplateArgs().data(),
                               spec_decl->getTemplateArgs().size());
-        if( QueryResults.size() )
+        if (QueryResults.size())
           return true;
       }
     }
-    
-    // TODO Shouldn't this be in the LookupInDeclContext function (or maybe even VisitDeclContex?)
-    DeclContext* parent = decl->getParent();
-    if( TagDecl* t_decl = dyn_cast_or_null<TagDecl>(parent) )
+
+    // TODO Shouldn't this be in the LookupInDeclContext function (or maybe even
+    // VisitDeclContex?)
+    DeclContext *parent = decl->getParent();
+    if (TagDecl *t_decl = dyn_cast_or_null<TagDecl>(parent))
       return getDerived().VisitTagDecl(t_decl);
     else {
       LookupInDeclContext(parent, true);
-      if( QueryResults.size() )
+      if (QueryResults.size())
         return true;
     }
-    
+
     return true;
   }
-  
-  
 };
 
-
-
-}
-
-
+} // namespace
 
 class TemplightDebugger::InteractiveAgent {
 public:
-  
-  void printEntryImpl(const TemplateDebuggerEntry& Entry) { 
-    llvm::outs() 
-      << ( (Entry.IsTemplateBegin) ? "Entering " : "Leaving  " )
-      << SynthesisKindStrings[Entry.Inst.Kind]  << " of " << Entry.Name << '\n'
-      << "  at " << Entry.FileName << '|' << Entry.Line << '|' << Entry.Column 
-      << " (Memory usage: " << Entry.MemoryUsage << ")\n";
-    if ( verboseMode ) {
-      std::string SrcPointer = getSrcPointer(TheSema, Entry.Inst.PointOfInstantiation);
-      if( !SrcPointer.empty() )
+  void printEntryImpl(const TemplateDebuggerEntry &Entry) {
+    llvm::outs() << ((Entry.IsTemplateBegin) ? "Entering " : "Leaving  ")
+                 << SynthesisKindStrings[Entry.Inst.Kind] << " of "
+                 << Entry.Name << '\n'
+                 << "  at " << Entry.FileName << '|' << Entry.Line << '|'
+                 << Entry.Column << " (Memory usage: " << Entry.MemoryUsage
+                 << ")\n";
+    if (verboseMode) {
+      std::string SrcPointer =
+          getSrcPointer(TheSema, Entry.Inst.PointOfInstantiation);
+      if (!SrcPointer.empty())
         llvm::outs() << SrcPointer << '\n';
     }
   };
-  
+
   void skipEntry(const TemplateDebuggerEntry &Entry) {
-    if ( CurrentSkippedEntry.IsTemplateBegin )
+    if (CurrentSkippedEntry.IsTemplateBegin)
       return; // Already skipping entries.
-    if ( !Entry.IsTemplateBegin )
+    if (!Entry.IsTemplateBegin)
       return; // Cannot skip entry that has ended already.
     CurrentSkippedEntry = Entry;
   };
-  
+
   struct breakpointMatchesStr {
     llvm::StringRef str;
-    breakpointMatchesStr(const std::string& aStr) : str(&aStr[0], aStr.size()) { };
-    bool operator()(std::pair<std::string,llvm::Regex>& aReg) const {
+    breakpointMatchesStr(const std::string &aStr)
+        : str(&aStr[0], aStr.size()){};
+    bool operator()(std::pair<std::string, llvm::Regex> &aReg) const {
       return aReg.second.match(str);
     };
   };
-  
+
   bool shouldIgnoreEntry(const TemplateDebuggerEntry &Entry) {
     // Check if it's been commanded to ignore things:
-    if ( ignoreAll )
+    if (ignoreAll)
       return true;
-    if ( ignoreUntilBreakpoint ) {
-      std::vector< std::pair<std::string,llvm::Regex> >::iterator it = std::find_if(
-        Breakpoints.begin(), Breakpoints.end(), breakpointMatchesStr(Entry.Name));
-      if ( it != Breakpoints.end() )
+    if (ignoreUntilBreakpoint) {
+      std::vector<std::pair<std::string, llvm::Regex>>::iterator it =
+          std::find_if(Breakpoints.begin(), Breakpoints.end(),
+                       breakpointMatchesStr(Entry.Name));
+      if (it != Breakpoints.end())
         return false;
       else
         return true;
     }
-    if ( ignoreUntilLastEnds ) {
-      if ( ( EntriesStack.size() > 0 )
-           && ( EntriesStack.back().Inst.Kind == Entry.Inst.Kind )
-           && ( EntriesStack.back().Inst.Entity == Entry.Inst.Entity ) )
+    if (ignoreUntilLastEnds) {
+      if ((EntriesStack.size() > 0) &&
+          (EntriesStack.back().Inst.Kind == Entry.Inst.Kind) &&
+          (EntriesStack.back().Inst.Entity == Entry.Inst.Entity))
         return false;
       else
         return true;
     }
-    
+
     // Check the black-lists:
     // (1) Is currently ignoring entries?
-    if ( CurrentSkippedEntry.IsTemplateBegin ) {
-      // Should skip the entry, but need to check if it's the last entry to skip:
-      if ( !Entry.IsTemplateBegin
-           && ( CurrentSkippedEntry.Inst.Kind == Entry.Inst.Kind )
-           && ( CurrentSkippedEntry.Inst.Entity == Entry.Inst.Entity ) ) {
+    if (CurrentSkippedEntry.IsTemplateBegin) {
+      // Should skip the entry, but need to check if it's the last entry to
+      // skip:
+      if (!Entry.IsTemplateBegin &&
+          (CurrentSkippedEntry.Inst.Kind == Entry.Inst.Kind) &&
+          (CurrentSkippedEntry.Inst.Entity == Entry.Inst.Entity)) {
         CurrentSkippedEntry.IsTemplateBegin = false;
       }
       return true;
     }
     // (2) Context:
-    if ( CoRegex ) {
-      if ( NamedDecl* p_context = dyn_cast_or_null<NamedDecl>(Entry.Inst.Entity->getDeclContext()) ) {
+    if (CoRegex) {
+      if (NamedDecl *p_context = dyn_cast_or_null<NamedDecl>(
+              Entry.Inst.Entity->getDeclContext())) {
         std::string co_name;
         llvm::raw_string_ostream OS(co_name);
         p_context->getNameForDiagnostic(OS, TheSema.getLangOpts(), true);
         OS.str(); // flush to string.
-        if ( CoRegex->match(co_name) ) {
+        if (CoRegex->match(co_name)) {
           skipEntry(Entry);
           return true;
         }
       }
     }
     // (3) Identifier:
-    if ( IdRegex ) {
-      if ( NamedDecl* p_ndecl = dyn_cast_or_null<NamedDecl>(Entry.Inst.Entity) ) {
+    if (IdRegex) {
+      if (NamedDecl *p_ndecl = dyn_cast_or_null<NamedDecl>(Entry.Inst.Entity)) {
         std::string id_name;
         llvm::raw_string_ostream OS(id_name);
         p_ndecl->getNameForDiagnostic(OS, TheSema.getLangOpts(), true);
         OS.str(); // flush to string.
-        if ( IdRegex->match(id_name) ) {
+        if (IdRegex->match(id_name)) {
           skipEntry(Entry);
           return true;
         }
       }
     }
-    
+
     // Avoid some duplication of memoization entries:
-    if ( Entry.Inst.Kind == Sema::CodeSynthesisContext::Memoization ) {
-      if ( !LastBeginEntry.IsTemplateBegin
-           && ( LastBeginEntry.Inst.Kind == Entry.Inst.Kind )
-           && ( LastBeginEntry.Inst.Entity == Entry.Inst.Entity ) ) {
+    if (Entry.Inst.Kind == Sema::CodeSynthesisContext::Memoization) {
+      if (!LastBeginEntry.IsTemplateBegin &&
+          (LastBeginEntry.Inst.Kind == Entry.Inst.Kind) &&
+          (LastBeginEntry.Inst.Entity == Entry.Inst.Entity)) {
         return true;
       }
     }
     return false;
   };
-  
-  static void getLineFromStdIn(std::string& s) {
+
+  static void getLineFromStdIn(std::string &s) {
     char c = 0;
     s = "";
     int i = std::getchar();
-    if ( i == EOF ) {
+    if (i == EOF) {
       std::clearerr(stdin);
       return;
     };
     c = char(i);
-    while ( c != '\n' ) {
+    while (c != '\n') {
       s.push_back(c);
       i = std::getchar();
-      if ( i == EOF ) {
+      if (i == EOF) {
         std::clearerr(stdin);
         return;
       };
       c = char(i);
     };
   };
-  
+
   static void flushStdIn() {
     std::string s;
     getLineFromStdIn(s);
   };
-  
-  static void getTokenizeCommand(const std::string& s, std::string& com, std::string& arg) {
+
+  static void getTokenizeCommand(const std::string &s, std::string &com,
+                                 std::string &arg) {
     com = "";
     unsigned i = 0;
-    while( ( i < s.size() ) && ( std::isspace(s[i]) ) )
+    while ((i < s.size()) && (std::isspace(s[i])))
       ++i;
-    while( ( i < s.size() ) && ( !std::isspace(s[i]) ) ) {
+    while ((i < s.size()) && (!std::isspace(s[i]))) {
       com += s[i];
       ++i;
     };
-    while( ( i < s.size() ) && ( std::isspace(s[i]) ) )
+    while ((i < s.size()) && (std::isspace(s[i])))
       ++i;
     unsigned e = s.size();
-    while( ( e > i ) && ( std::isspace(s[e-1]) ) )
+    while ((e > i) && (std::isspace(s[e - 1])))
       --e;
     arg = s.substr(i, e - i);
   };
-  
+
   void processInputs() {
     std::string user_in;
-    while(true) {
+    while (true) {
       llvm::outs() << "(tdb) ";
       llvm::outs().flush();
       getLineFromStdIn(user_in);
-      if ( user_in == "" )
+      if (user_in == "")
         user_in = LastUserCommand;
-      
+
       LastUserCommand = user_in;
-      
+
       std::string user_command, com_arg;
       getTokenizeCommand(user_in, user_command, com_arg);
-      
-      if ( ( user_command == "i" ) ||
-           ( user_command == "info" ) ) {
-        if ( ( com_arg == "f" ) ||
-             ( com_arg == "frame" ) ) {
-          if ( EntriesStack.size() > 0 )
+
+      if ((user_command == "i") || (user_command == "info")) {
+        if ((com_arg == "f") || (com_arg == "frame")) {
+          if (EntriesStack.size() > 0)
             printEntryImpl(EntriesStack.back());
           continue;
-        }
-        else if ( ( com_arg == "b" ) ||
-                  ( com_arg == "break" ) ) {
-          for(unsigned i = 0; i < Breakpoints.size(); ++i)
-            if ( !Breakpoints[i].second.match("-") )
-              llvm::outs() << "Breakpoint " << i 
-                           << " for " << Breakpoints[i].first << '\n';
+        } else if ((com_arg == "b") || (com_arg == "break")) {
+          for (unsigned i = 0; i < Breakpoints.size(); ++i)
+            if (!Breakpoints[i].second.match("-"))
+              llvm::outs() << "Breakpoint " << i << " for "
+                           << Breakpoints[i].first << '\n';
           continue;
-        }
-        else if ( ( com_arg == "s" ) ||
-                  ( com_arg == "stack" ) ) {
+        } else if ((com_arg == "s") || (com_arg == "stack")) {
           user_command = "bt";
-        }
-        else {
+        } else {
           llvm::outs() << "Invalid input!\n";
           continue;
         }
-        
       }
-      
-      if ( user_command == "setmode" ) {
-        if ( com_arg == "verbose" ) {
+
+      if (user_command == "setmode") {
+        if (com_arg == "verbose") {
           verboseMode = true;
           continue;
-        }
-        else if ( com_arg == "quiet" ) {
+        } else if (com_arg == "quiet") {
           verboseMode = false;
           continue;
-        }
-        else {
+        } else {
           llvm::outs() << "Invalid setmode command!\n";
           continue;
         }
       }
-      
-      if ( ( user_command == "r" ) ||
-           ( user_command == "c" ) ||
-           ( user_command == "run" ) ||
-           ( user_command == "continue" ) ) {
+
+      if ((user_command == "r") || (user_command == "c") ||
+          (user_command == "run") || (user_command == "continue")) {
         ignoreAll = false;
         ignoreUntilLastEnds = false;
         ignoreUntilBreakpoint = true;
         return;
-      }
-      else if ( ( user_command == "k" ) ||
-                ( user_command == "q" ) ||
-                ( user_command == "kill" ) ||
-                ( user_command == "quit" ) ) {
+      } else if ((user_command == "k") || (user_command == "q") ||
+                 (user_command == "kill") || (user_command == "quit")) {
         ignoreAll = true;
         ignoreUntilLastEnds = false;
         ignoreUntilBreakpoint = false;
         return;
-      }
-      else if ( ( user_command == "n" ) ||
-                ( user_command == "next" ) ) {
+      } else if ((user_command == "n") || (user_command == "next")) {
         ignoreAll = false;
         ignoreUntilLastEnds = (EntriesStack.size() > 0);
         ignoreUntilBreakpoint = false;
         return;
-      }
-      else if ( ( user_command == "s" ) ||
-                ( user_command == "step" ) ) {
+      } else if ((user_command == "s") || (user_command == "step")) {
         ignoreAll = false;
         ignoreUntilLastEnds = false;
         ignoreUntilBreakpoint = false;
         return;
-      }
-      else if ( ( user_command == "l" ) ||
-                ( user_command == "lookup" ) ) {
-        TemplateArgRecorder rec(TheSema, "^" + llvm::Regex::escape(com_arg) + "$", 
+      } else if ((user_command == "l") || (user_command == "lookup")) {
+        TemplateArgRecorder rec(TheSema,
+                                "^" + llvm::Regex::escape(com_arg) + "$",
                                 TemplateArgRecorder::LookForDecl);
-        if( EntriesStack.empty() )
+        if (EntriesStack.empty())
           rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
         else
           rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() 
-            << "Found " << it->Name << '\n'
-            << "  at " << it->FileName << '|' << it->Line << '|' << it->Column << '\n';
-          if( verboseMode && !it->SrcPointer.empty() )
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << "Found " << it->Name << '\n'
+                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << it->Column << '\n';
+          if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
         };
         continue;
-      }
-      else if ( ( user_command == "rl" ) ||
-                ( user_command == "rlookup" ) ) {
-        TemplateArgRecorder rec(TheSema, com_arg, TemplateArgRecorder::LookForDecl);
-        if( EntriesStack.empty() )
-          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
-        else
-          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() 
-            << "Found " << it->Name << '\n'
-            << "  at " << it->FileName << '|' << it->Line << '|' << it->Column << '\n';
-          if( verboseMode && !it->SrcPointer.empty() )
-            llvm::outs() << it->SrcPointer << '\n';
-        };
-        continue;
-      }
-      else if ( ( user_command == "t" ) ||
-                ( user_command == "typeof" ) ) {
-        TemplateArgRecorder rec(TheSema, "^" + llvm::Regex::escape(com_arg) + "$",
-                                TemplateArgRecorder::LookForType);
-        if( EntriesStack.empty() )
-          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
-        else
-          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() 
-            << "Found " << it->Name << '\n'
-            << "  at " << it->FileName << '|' << it->Line << '|' << it->Column << '\n';
-          if( verboseMode && !it->SrcPointer.empty() )
-            llvm::outs() << it->SrcPointer << '\n';
-        };
-        continue;
-      }
-      else if ( ( user_command == "rt" ) ||
-                ( user_command == "rtypeof" ) ) {
-        TemplateArgRecorder rec(TheSema, com_arg, TemplateArgRecorder::LookForType);
-        if( EntriesStack.empty() )
-          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
-        else
-          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() 
-            << "Found " << it->Name << '\n'
-            << "  at " << it->FileName << '|' << it->Line << '|' << it->Column << '\n';
-          if( verboseMode && !it->SrcPointer.empty() )
-            llvm::outs() << it->SrcPointer << '\n';
-        };
-        continue;
-      }
-      else if ( ( user_command == "e" ) ||
-                ( user_command == "eval" ) ) {
-        TemplateArgRecorder rec(TheSema, "^" + llvm::Regex::escape(com_arg) + "$", 
-                                TemplateArgRecorder::LookForValue);
-        if( EntriesStack.empty() )
-          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
-        else
-          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() << it->Name << '\n';
-        };
-        continue;
-      }
-      else if ( ( user_command == "re" ) ||
-                ( user_command == "reval" ) ) {
-        TemplateArgRecorder rec(TheSema, com_arg, TemplateArgRecorder::LookForValue);
-        if( EntriesStack.empty() )
-          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
-        else
-          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() << it->Name << '\n';
-        };
-        continue;
-      }
-      else if ( ( user_command == "w" ) ||
-                ( user_command == "whois" ) ) {
-        TemplateArgRecorder rec(TheSema, "^" + llvm::Regex::escape(com_arg) + "$", 
-                                TemplateArgRecorder::LookForDecl | 
-                                TemplateArgRecorder::LookForType | 
-                                TemplateArgRecorder::LookForValue);
-        if( EntriesStack.empty() )
-          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
-        else
-          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() 
-            << "Found " << it->Name << '\n'
-            << "  at " << it->FileName << '|' << it->Line << '|' << it->Column << '\n';
-          if( verboseMode && !it->SrcPointer.empty() )
-            llvm::outs() << it->SrcPointer << '\n';
-        };
-        continue;
-      }
-      else if ( ( user_command == "rw" ) ||
-                ( user_command == "rwhois" ) ) {
+      } else if ((user_command == "rl") || (user_command == "rlookup")) {
         TemplateArgRecorder rec(TheSema, com_arg,
-                                TemplateArgRecorder::LookForDecl | 
-                                TemplateArgRecorder::LookForType | 
-                                TemplateArgRecorder::LookForValue);
-        if( EntriesStack.empty() )
+                                TemplateArgRecorder::LookForDecl);
+        if (EntriesStack.empty())
           rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
         else
           rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
-        for(std::vector<TemplateArgRecorder::PrintableQueryResult>::const_iterator it = rec.QueryResults.begin();
-            it != rec.QueryResults.end(); ++it) {
-          llvm::outs() 
-            << "Found " << it->Name << '\n'
-            << "  at " << it->FileName << '|' << it->Line << '|' << it->Column << '\n';
-          if( verboseMode && !it->SrcPointer.empty() )
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << "Found " << it->Name << '\n'
+                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << it->Column << '\n';
+          if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
         };
         continue;
-      }
-      else if ( ( user_command == "b" ) ||
-                ( user_command == "break" ) ) {
-        std::vector< std::pair<std::string,llvm::Regex> >::iterator it = std::find_if(
-          Breakpoints.begin(), Breakpoints.end(), breakpointMatchesStr(com_arg));
-        if ( it == Breakpoints.end() ) {
-          it = std::find_if(Breakpoints.begin(), Breakpoints.end(), breakpointMatchesStr("-"));
-          if ( it == Breakpoints.end() )
-            it = Breakpoints.insert(Breakpoints.end(), 
-                                    std::pair<std::string,llvm::Regex>(llvm::Regex::escape(com_arg), 
-                                                                       llvm::Regex(llvm::Regex::escape(com_arg))));
-          else
-            *it = std::pair<std::string,llvm::Regex>(llvm::Regex::escape(com_arg), 
-                                                     llvm::Regex(llvm::Regex::escape(com_arg)));
-        }
-        llvm::outs() << "Breakpoint " << (it - Breakpoints.begin()) 
-                     << " for " << com_arg << '\n';
-        continue;
-      }
-      else if ( ( user_command == "rb" ) ||
-                ( user_command == "rbreak" ) ) {
-        std::vector< std::pair<std::string,llvm::Regex> >::iterator it = 
-          std::find_if(Breakpoints.begin(), Breakpoints.end(), breakpointMatchesStr("-"));
-        if ( it == Breakpoints.end() )
-          it = Breakpoints.insert(Breakpoints.end(), 
-                                  std::pair<std::string,llvm::Regex>(com_arg, 
-                                                                     llvm::Regex(com_arg)));
+      } else if ((user_command == "t") || (user_command == "typeof")) {
+        TemplateArgRecorder rec(TheSema,
+                                "^" + llvm::Regex::escape(com_arg) + "$",
+                                TemplateArgRecorder::LookForType);
+        if (EntriesStack.empty())
+          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
         else
-          *it = std::pair<std::string,llvm::Regex>(com_arg, 
-                                                   llvm::Regex(com_arg));
-        llvm::outs() << "Breakpoint " << (it - Breakpoints.begin()) 
-                     << " for " << com_arg << '\n';
+          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << "Found " << it->Name << '\n'
+                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << it->Column << '\n';
+          if (verboseMode && !it->SrcPointer.empty())
+            llvm::outs() << it->SrcPointer << '\n';
+        };
         continue;
-      }
-      else if ( ( user_command == "d" ) ||
-                ( user_command == "delete" ) ) {
+      } else if ((user_command == "rt") || (user_command == "rtypeof")) {
+        TemplateArgRecorder rec(TheSema, com_arg,
+                                TemplateArgRecorder::LookForType);
+        if (EntriesStack.empty())
+          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
+        else
+          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << "Found " << it->Name << '\n'
+                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << it->Column << '\n';
+          if (verboseMode && !it->SrcPointer.empty())
+            llvm::outs() << it->SrcPointer << '\n';
+        };
+        continue;
+      } else if ((user_command == "e") || (user_command == "eval")) {
+        TemplateArgRecorder rec(TheSema,
+                                "^" + llvm::Regex::escape(com_arg) + "$",
+                                TemplateArgRecorder::LookForValue);
+        if (EntriesStack.empty())
+          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
+        else
+          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << it->Name << '\n';
+        };
+        continue;
+      } else if ((user_command == "re") || (user_command == "reval")) {
+        TemplateArgRecorder rec(TheSema, com_arg,
+                                TemplateArgRecorder::LookForValue);
+        if (EntriesStack.empty())
+          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
+        else
+          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << it->Name << '\n';
+        };
+        continue;
+      } else if ((user_command == "w") || (user_command == "whois")) {
+        TemplateArgRecorder rec(TheSema,
+                                "^" + llvm::Regex::escape(com_arg) + "$",
+                                TemplateArgRecorder::LookForDecl |
+                                    TemplateArgRecorder::LookForType |
+                                    TemplateArgRecorder::LookForValue);
+        if (EntriesStack.empty())
+          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
+        else
+          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << "Found " << it->Name << '\n'
+                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << it->Column << '\n';
+          if (verboseMode && !it->SrcPointer.empty())
+            llvm::outs() << it->SrcPointer << '\n';
+        };
+        continue;
+      } else if ((user_command == "rw") || (user_command == "rwhois")) {
+        TemplateArgRecorder rec(TheSema, com_arg,
+                                TemplateArgRecorder::LookForDecl |
+                                    TemplateArgRecorder::LookForType |
+                                    TemplateArgRecorder::LookForValue);
+        if (EntriesStack.empty())
+          rec.LookupInDeclContext(TheSema.getCurLexicalContext(), true);
+        else
+          rec.TraverseActiveTempInstantiation(EntriesStack.back().Inst);
+        for (std::vector<
+                 TemplateArgRecorder::PrintableQueryResult>::const_iterator it =
+                 rec.QueryResults.begin();
+             it != rec.QueryResults.end(); ++it) {
+          llvm::outs() << "Found " << it->Name << '\n'
+                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << it->Column << '\n';
+          if (verboseMode && !it->SrcPointer.empty())
+            llvm::outs() << it->SrcPointer << '\n';
+        };
+        continue;
+      } else if ((user_command == "b") || (user_command == "break")) {
+        std::vector<std::pair<std::string, llvm::Regex>>::iterator it =
+            std::find_if(Breakpoints.begin(), Breakpoints.end(),
+                         breakpointMatchesStr(com_arg));
+        if (it == Breakpoints.end()) {
+          it = std::find_if(Breakpoints.begin(), Breakpoints.end(),
+                            breakpointMatchesStr("-"));
+          if (it == Breakpoints.end())
+            it = Breakpoints.insert(
+                Breakpoints.end(),
+                std::pair<std::string, llvm::Regex>(
+                    llvm::Regex::escape(com_arg),
+                    llvm::Regex(llvm::Regex::escape(com_arg))));
+          else
+            *it = std::pair<std::string, llvm::Regex>(
+                llvm::Regex::escape(com_arg),
+                llvm::Regex(llvm::Regex::escape(com_arg)));
+        }
+        llvm::outs() << "Breakpoint " << (it - Breakpoints.begin()) << " for "
+                     << com_arg << '\n';
+        continue;
+      } else if ((user_command == "rb") || (user_command == "rbreak")) {
+        std::vector<std::pair<std::string, llvm::Regex>>::iterator it =
+            std::find_if(Breakpoints.begin(), Breakpoints.end(),
+                         breakpointMatchesStr("-"));
+        if (it == Breakpoints.end())
+          it = Breakpoints.insert(Breakpoints.end(),
+                                  std::pair<std::string, llvm::Regex>(
+                                      com_arg, llvm::Regex(com_arg)));
+        else
+          *it = std::pair<std::string, llvm::Regex>(com_arg,
+                                                    llvm::Regex(com_arg));
+        llvm::outs() << "Breakpoint " << (it - Breakpoints.begin()) << " for "
+                     << com_arg << '\n';
+        continue;
+      } else if ((user_command == "d") || (user_command == "delete")) {
         int ind = 0;
-        if ( std::sscanf(com_arg.c_str(), "%d", &ind) < 1 ) {
+        if (std::sscanf(com_arg.c_str(), "%d", &ind) < 1) {
           llvm::outs() << "Invalid input!\n";
           continue;
         }
-        llvm::outs() << "Deleted breakpoint " << ind 
-                     << " for " << Breakpoints[ind].first << '\n';
-        Breakpoints[ind] = std::pair<std::string,llvm::Regex>("-", llvm::Regex("^-$"));
+        llvm::outs() << "Deleted breakpoint " << ind << " for "
+                     << Breakpoints[ind].first << '\n';
+        Breakpoints[ind] =
+            std::pair<std::string, llvm::Regex>("-", llvm::Regex("^-$"));
         continue;
-      }
-      else if ( ( user_command == "bt" ) ||
-                ( user_command == "backtrace" ) ||
-                ( user_command == "where" ) ) {
-        for(std::vector<TemplateDebuggerEntry>::reverse_iterator it = EntriesStack.rbegin();
-            it != EntriesStack.rend(); ++it) {
-          llvm::outs()
-            << SynthesisKindStrings[it->Inst.Kind] << " of " << it->Name 
-            << " at " << it->FileName << '|' 
-            << it->Line << '|' << it->Column << '\n';
+      } else if ((user_command == "bt") || (user_command == "backtrace") ||
+                 (user_command == "where")) {
+        for (std::vector<TemplateDebuggerEntry>::reverse_iterator it =
+                 EntriesStack.rbegin();
+             it != EntriesStack.rend(); ++it) {
+          llvm::outs() << SynthesisKindStrings[it->Inst.Kind] << " of "
+                       << it->Name << " at " << it->FileName << '|' << it->Line
+                       << '|' << it->Column << '\n';
         }
         continue;
-      }
-      else {
+      } else {
         llvm::outs() << "Invalid input!\n";
-        continue; 
+        continue;
       }
-      
     };
   };
-  
+
   void printRawEntry(const TemplateDebuggerEntry &Entry) {
-    if ( shouldIgnoreEntry(Entry) )
+    if (shouldIgnoreEntry(Entry))
       return;
-    
-    if ( Entry.IsTemplateBegin ) {
+
+    if (Entry.IsTemplateBegin) {
       EntriesStack.push_back(Entry);
       LastBeginEntry = Entry;
     };
-    
+
     printEntryImpl(Entry);
-    
-    if ( !Entry.IsTemplateBegin && 
-         ( Entry.Inst.Kind == Sema::CodeSynthesisContext::Memoization ) )
+
+    if (!Entry.IsTemplateBegin &&
+        (Entry.Inst.Kind == Sema::CodeSynthesisContext::Memoization))
       LastBeginEntry.IsTemplateBegin = false;
-    
-    if ( !Entry.IsTemplateBegin && 
-         ( EntriesStack.size() > 0 ) &&
-         ( Entry.Inst.Kind == EntriesStack.back().Inst.Kind ) &&
-         ( Entry.Inst.Entity == EntriesStack.back().Inst.Entity ) ) {
+
+    if (!Entry.IsTemplateBegin && (EntriesStack.size() > 0) &&
+        (Entry.Inst.Kind == EntriesStack.back().Inst.Kind) &&
+        (Entry.Inst.Entity == EntriesStack.back().Inst.Entity)) {
       EntriesStack.pop_back();
     };
-    
+
     processInputs();
   };
-  
+
   void startTrace() {
     llvm::outs() << "Welcome to the Templight debugger!\n"
                  << "Begin by entering 'run' after setting breakpoints.\n";
     processInputs();
   };
-  
+
   void endTrace() {
     llvm::outs() << "Templight debugging session has ended. Goodbye!\n";
   };
-  
-  InteractiveAgent(const Sema &aTheSema) : TheSema(aTheSema), ignoreAll(false), 
-    ignoreUntilLastEnds(false), ignoreUntilBreakpoint(false), verboseMode(false) {
+
+  InteractiveAgent(const Sema &aTheSema)
+      : TheSema(aTheSema), ignoreAll(false), ignoreUntilLastEnds(false),
+        ignoreUntilBreakpoint(false), verboseMode(false) {
     CurrentSkippedEntry.IsTemplateBegin = false;
   };
-  
-  ~InteractiveAgent() { };
-  
+
+  ~InteractiveAgent(){};
+
   const Sema &TheSema;
-  
+
   std::vector<TemplateDebuggerEntry> EntriesStack;
   TemplateDebuggerEntry LastBeginEntry;
-  
-  std::vector< std::pair<std::string,llvm::Regex> > Breakpoints;
-  
+
+  std::vector<std::pair<std::string, llvm::Regex>> Breakpoints;
+
   std::string LastUserCommand;
-  
+
   TemplateDebuggerEntry CurrentSkippedEntry;
   std::unique_ptr<llvm::Regex> CoRegex;
   std::unique_ptr<llvm::Regex> IdRegex;
-  
+
   unsigned ignoreAll : 1;
   unsigned ignoreUntilLastEnds : 1;
   unsigned ignoreUntilBreakpoint : 1;
   unsigned verboseMode : 1;
 };
 
+void TemplightDebugger::initialize(const Sema &) { Interactor->startTrace(); }
 
+void TemplightDebugger::finalize(const Sema &) { Interactor->endTrace(); }
 
-
-
-
-void TemplightDebugger::initialize(const Sema &) {
-  Interactor->startTrace();
-}
-
-void TemplightDebugger::finalize(const Sema &) {
-  Interactor->endTrace();
-}
-
-void TemplightDebugger::atTemplateBegin(const Sema &TheSema,
-                          const Sema::CodeSynthesisContext& Inst) {
-  if ( IgnoreSystemFlag && !Inst.PointOfInstantiation.isInvalid() && 
-       TheSema.getSourceManager()
-         .isInSystemHeader(Inst.PointOfInstantiation) )
+void TemplightDebugger::atTemplateBegin(
+    const Sema &TheSema, const Sema::CodeSynthesisContext &Inst) {
+  if (IgnoreSystemFlag && !Inst.PointOfInstantiation.isInvalid() &&
+      TheSema.getSourceManager().isInSystemHeader(Inst.PointOfInstantiation))
     return;
-  
+
   TemplateDebuggerEntry Entry(
-    true, (MemoryFlag ? llvm::sys::Process::GetMallocUsage() : 0), TheSema, Inst);
-  
+      true, (MemoryFlag ? llvm::sys::Process::GetMallocUsage() : 0), TheSema,
+      Inst);
+
   Interactor->printRawEntry(Entry);
 }
 
 void TemplightDebugger::atTemplateEnd(const Sema &TheSema,
-                          const Sema::CodeSynthesisContext& Inst) {
-  if ( IgnoreSystemFlag && !Inst.PointOfInstantiation.isInvalid() && 
-       TheSema.getSourceManager()
-         .isInSystemHeader(Inst.PointOfInstantiation) )
+                                      const Sema::CodeSynthesisContext &Inst) {
+  if (IgnoreSystemFlag && !Inst.PointOfInstantiation.isInvalid() &&
+      TheSema.getSourceManager().isInSystemHeader(Inst.PointOfInstantiation))
     return;
-  
+
   TemplateDebuggerEntry Entry(
-    false, (MemoryFlag ? llvm::sys::Process::GetMallocUsage() : 0), TheSema, Inst);
-  
+      false, (MemoryFlag ? llvm::sys::Process::GetMallocUsage() : 0), TheSema,
+      Inst);
+
   Interactor->printRawEntry(Entry);
 }
 
-
-TemplightDebugger::TemplightDebugger(const Sema &TheSema,
-                                     bool Memory, bool IgnoreSystem) :
-                                     MemoryFlag(Memory),
-                                     IgnoreSystemFlag(IgnoreSystem) {
+TemplightDebugger::TemplightDebugger(const Sema &TheSema, bool Memory,
+                                     bool IgnoreSystem)
+    : MemoryFlag(Memory), IgnoreSystemFlag(IgnoreSystem) {
   Interactor.reset(new InteractiveAgent(TheSema));
 }
 
-
-TemplightDebugger::~TemplightDebugger() { 
+TemplightDebugger::~TemplightDebugger() {
   // must be defined here due to TracePrinter being incomplete in header.
 }
 
-void TemplightDebugger::readBlacklists(const std::string& BLFilename) {
-  if ( !Interactor || BLFilename.empty() ) {
+void TemplightDebugger::readBlacklists(const std::string &BLFilename) {
+  if (!Interactor || BLFilename.empty()) {
     Interactor->CoRegex.reset();
     Interactor->IdRegex.reset();
     return;
   }
-  
+
   std::string CoPattern, IdPattern;
-  
-  llvm::ErrorOr< std::unique_ptr<llvm::MemoryBuffer> >
-    file_epbuf = llvm::MemoryBuffer::getFile(llvm::Twine(BLFilename));
-  if(!file_epbuf || (!file_epbuf.get())) {
-    llvm::errs() << "Error: [Templight-Action] Could not open the blacklist file!\n";
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> file_epbuf =
+      llvm::MemoryBuffer::getFile(llvm::Twine(BLFilename));
+  if (!file_epbuf || (!file_epbuf.get())) {
+    llvm::errs()
+        << "Error: [Templight-Action] Could not open the blacklist file!\n";
     Interactor->CoRegex.reset();
     Interactor->IdRegex.reset();
     return;
   }
-  
+
   llvm::Regex findCo("^context ");
   llvm::Regex findId("^identifier ");
-  
-  const char* it      = file_epbuf.get()->getBufferStart();
-  const char* it_mark = file_epbuf.get()->getBufferStart();
-  const char* it_end  = file_epbuf.get()->getBufferEnd();
-  
-  while( it_mark != it_end ) {
+
+  const char *it = file_epbuf.get()->getBufferStart();
+  const char *it_mark = file_epbuf.get()->getBufferStart();
+  const char *it_end = file_epbuf.get()->getBufferEnd();
+
+  while (it_mark != it_end) {
     it_mark = std::find(it, it_end, '\n');
-    if(*(it_mark-1) == '\r')
+    if (*(it_mark - 1) == '\r')
       --it_mark;
     llvm::StringRef curLine(&(*it), it_mark - it);
-    if( findCo.match(curLine) ) {
-      if(!CoPattern.empty())
+    if (findCo.match(curLine)) {
+      if (!CoPattern.empty())
         CoPattern += '|';
       CoPattern += '(';
-      CoPattern.append(&(*(it+8)), it_mark - it - 8);
+      CoPattern.append(&(*(it + 8)), it_mark - it - 8);
       CoPattern += ')';
-    } else if( findId.match(curLine) ) {
-      if(!IdPattern.empty())
+    } else if (findId.match(curLine)) {
+      if (!IdPattern.empty())
         IdPattern += '|';
       IdPattern += '(';
-      IdPattern.append(&(*(it+11)), it_mark - it - 11);
+      IdPattern.append(&(*(it + 11)), it_mark - it - 11);
       IdPattern += ')';
     }
-    while( (it_mark != it_end) && 
-           ((*it_mark == '\n') || (*it_mark == '\r')) )
+    while ((it_mark != it_end) && ((*it_mark == '\n') || (*it_mark == '\r')))
       ++it_mark;
     it = it_mark;
   }
-  
+
   Interactor->CoRegex.reset(new llvm::Regex(CoPattern));
   Interactor->IdRegex.reset(new llvm::Regex(IdPattern));
   return;
 }
 
-
 } // namespace clang
-

--- a/lib/TemplightEntryPrinter.cpp
+++ b/lib/TemplightEntryPrinter.cpp
@@ -1,4 +1,4 @@
-//===- TemplightEntryPrinter.cpp ------ Clang Templight Entry Printer -*- C++ -*-===//
+//===- TemplightEntryPrinter.cpp --------------------*- C++ -*-------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -11,85 +11,89 @@
 
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/MemoryBuffer.h>
-#include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/Regex.h>
-
+#include <llvm/Support/raw_ostream.h>
 
 namespace clang {
 
-
 void TemplightEntryPrinter::skipEntry() {
-  if ( SkippedEndingsCount ) {
-    ++SkippedEndingsCount; // note: this is needed because skipped entries are begin entries for which "shouldIgnoreEntry" is never called.
-    return; // Already skipping entries.
+  if (SkippedEndingsCount) {
+    ++SkippedEndingsCount; // note: this is needed because skipped entries are
+                           // begin entries for which "shouldIgnoreEntry" is
+                           // never called.
+    return;                // Already skipping entries.
   }
   SkippedEndingsCount = 1;
 }
 
-bool TemplightEntryPrinter::shouldIgnoreEntry(const PrintableTemplightEntryBegin &Entry) {
+bool TemplightEntryPrinter::shouldIgnoreEntry(
+    const PrintableTemplightEntryBegin &Entry) {
   // Check the black-lists:
   // (1) Is currently ignoring entries?
-  if ( SkippedEndingsCount ) {
+  if (SkippedEndingsCount) {
     ++SkippedEndingsCount;
     return true;
   }
   // (2) Regexes:
-  if ( ( CoRegex && ( CoRegex->match(Entry.Name) ) ) || 
-       ( IdRegex && ( IdRegex->match(Entry.Name) ) ) ) {
+  if ((CoRegex && (CoRegex->match(Entry.Name))) ||
+      (IdRegex && (IdRegex->match(Entry.Name)))) {
     skipEntry();
     return true;
   }
-  
+
   return false;
 }
 
-bool TemplightEntryPrinter::shouldIgnoreEntry(const PrintableTemplightEntryEnd &Entry) {
+bool TemplightEntryPrinter::shouldIgnoreEntry(
+    const PrintableTemplightEntryEnd &Entry) {
   // Check the black-lists:
   // (1) Is currently ignoring entries?
-  if ( SkippedEndingsCount ) {
+  if (SkippedEndingsCount) {
     --SkippedEndingsCount;
     return true;
   }
   return false;
 }
 
-
-void TemplightEntryPrinter::printEntry(const PrintableTemplightEntryBegin &Entry) {
-  if ( shouldIgnoreEntry(Entry) )
+void TemplightEntryPrinter::printEntry(
+    const PrintableTemplightEntryBegin &Entry) {
+  if (shouldIgnoreEntry(Entry))
     return;
-  
-  if ( p_writer )
+
+  if (p_writer)
     p_writer->printEntry(Entry);
 }
 
-void TemplightEntryPrinter::printEntry(const PrintableTemplightEntryEnd &Entry) {
-  if ( shouldIgnoreEntry(Entry) )
+void TemplightEntryPrinter::printEntry(
+    const PrintableTemplightEntryEnd &Entry) {
+  if (shouldIgnoreEntry(Entry))
     return;
-  
-  if ( p_writer )
+
+  if (p_writer)
     p_writer->printEntry(Entry);
 }
 
-void TemplightEntryPrinter::initialize(const std::string& SourceName) {
-  if ( p_writer )
+void TemplightEntryPrinter::initialize(const std::string &SourceName) {
+  if (p_writer)
     p_writer->initialize(SourceName);
 }
 
 void TemplightEntryPrinter::finalize() {
-  if ( p_writer )
+  if (p_writer)
     p_writer->finalize();
 }
 
-TemplightEntryPrinter::TemplightEntryPrinter(const std::string &Output) : SkippedEndingsCount(0), TraceOS(0) {
-  if ( Output == "-" ) {
+TemplightEntryPrinter::TemplightEntryPrinter(const std::string &Output)
+    : SkippedEndingsCount(0), TraceOS(0) {
+  if (Output == "-") {
     TraceOS = &llvm::outs();
   } else {
     std::error_code error;
     TraceOS = new llvm::raw_fd_ostream(Output, error, llvm::sys::fs::F_None);
-    if ( error ) {
-      llvm::errs() <<
-        "Error: [Templight] Can not open file to write trace of template instantiations: "
-        << Output << " Error: " << error.message();
+    if (error) {
+      llvm::errs() << "Error: [Templight] Can not open file to write trace of "
+                      "template instantiations: "
+                   << Output << " Error: " << error.message();
       TraceOS = 0;
       return;
     }
@@ -98,75 +102,75 @@ TemplightEntryPrinter::TemplightEntryPrinter(const std::string &Output) : Skippe
 
 TemplightEntryPrinter::~TemplightEntryPrinter() {
   p_writer.reset(); // Delete writer before the trace-OS.
-  if ( TraceOS ) {
+  if (TraceOS) {
     TraceOS->flush();
-    if ( TraceOS != &llvm::outs() )
+    if (TraceOS != &llvm::outs())
       delete TraceOS;
   }
 }
 
 bool TemplightEntryPrinter::isValid() const { return p_writer.get(); }
 
-llvm::raw_ostream* TemplightEntryPrinter::getTraceStream() const { return TraceOS; }
+llvm::raw_ostream *TemplightEntryPrinter::getTraceStream() const {
+  return TraceOS;
+}
 
-void TemplightEntryPrinter::takeWriter(TemplightWriter* aPWriter) {
+void TemplightEntryPrinter::takeWriter(TemplightWriter *aPWriter) {
   p_writer.reset(aPWriter);
 }
 
-void TemplightEntryPrinter::readBlacklists(const std::string& BLFilename) {
-  if ( BLFilename.empty() ) {
+void TemplightEntryPrinter::readBlacklists(const std::string &BLFilename) {
+  if (BLFilename.empty()) {
     CoRegex.reset();
     IdRegex.reset();
     return;
   }
-  
+
   std::string CoPattern, IdPattern;
-  
-  llvm::ErrorOr< std::unique_ptr<llvm::MemoryBuffer> >
-    file_epbuf = llvm::MemoryBuffer::getFile(llvm::Twine(BLFilename));
-  if(!file_epbuf || (!file_epbuf.get())) {
-    llvm::errs() << "Error: [Templight-Action] Could not open the blacklist file!\n";
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> file_epbuf =
+      llvm::MemoryBuffer::getFile(llvm::Twine(BLFilename));
+  if (!file_epbuf || (!file_epbuf.get())) {
+    llvm::errs()
+        << "Error: [Templight-Action] Could not open the blacklist file!\n";
     CoRegex.reset();
     IdRegex.reset();
     return;
   }
-  
+
   llvm::Regex findCo("^context ");
   llvm::Regex findId("^identifier ");
-  
-  const char* it      = file_epbuf.get()->getBufferStart();
-  const char* it_mark = file_epbuf.get()->getBufferStart();
-  const char* it_end  = file_epbuf.get()->getBufferEnd();
-  
-  while( it_mark != it_end ) {
+
+  const char *it = file_epbuf.get()->getBufferStart();
+  const char *it_mark = file_epbuf.get()->getBufferStart();
+  const char *it_end = file_epbuf.get()->getBufferEnd();
+
+  while (it_mark != it_end) {
     it_mark = std::find(it, it_end, '\n');
-    if(*(it_mark-1) == '\r')
+    if (*(it_mark - 1) == '\r')
       --it_mark;
     llvm::StringRef curLine(&(*it), it_mark - it);
-    if( findCo.match(curLine) ) {
-      if(!CoPattern.empty())
+    if (findCo.match(curLine)) {
+      if (!CoPattern.empty())
         CoPattern += '|';
       CoPattern += '(';
-      CoPattern.append(&(*(it+8)), it_mark - it - 8);
+      CoPattern.append(&(*(it + 8)), it_mark - it - 8);
       CoPattern += ')';
-    } else if( findId.match(curLine) ) {
-      if(!IdPattern.empty())
+    } else if (findId.match(curLine)) {
+      if (!IdPattern.empty())
         IdPattern += '|';
       IdPattern += '(';
-      IdPattern.append(&(*(it+11)), it_mark - it - 11);
+      IdPattern.append(&(*(it + 11)), it_mark - it - 11);
       IdPattern += ')';
     }
-    while( (it_mark != it_end) && 
-           ((*it_mark == '\n') || (*it_mark == '\r')) )
+    while ((it_mark != it_end) && ((*it_mark == '\n') || (*it_mark == '\r')))
       ++it_mark;
     it = it_mark;
   }
-  
+
   CoRegex.reset(new llvm::Regex(CoPattern));
   IdRegex.reset(new llvm::Regex(IdPattern));
   return;
 }
 
-
-}
-
+} // namespace clang

--- a/lib/TemplightProtobufWriter.cpp
+++ b/lib/TemplightProtobufWriter.cpp
@@ -1,4 +1,4 @@
-//===- TemplightProtobufWriter.cpp ------ Clang Templight Protobuf Writer -*- C++ -*-===//
+//===- TemplightProtobufWriter.cpp ------------*- C++ -*-------------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -12,42 +12,41 @@
 
 #include "ThinProtobuf.h"
 
-#include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/Compression.h>
 #include <llvm/Support/Error.h>
+#include <llvm/Support/raw_ostream.h>
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace clang {
 
+TemplightProtobufWriter::TemplightProtobufWriter(llvm::raw_ostream &aOS,
+                                                 int aCompressLevel)
+    : TemplightWriter(aOS), compressionMode(aCompressLevel) {}
 
-TemplightProtobufWriter::TemplightProtobufWriter(llvm::raw_ostream& aOS, int aCompressLevel) : 
-  TemplightWriter(aOS), compressionMode(aCompressLevel) { }
+void TemplightProtobufWriter::initialize(const std::string &aSourceName) {
 
-void TemplightProtobufWriter::initialize(const std::string& aSourceName) {
-  
   std::string hdr_contents;
   {
     llvm::raw_string_ostream OS_inner(hdr_contents);
-    
+
     /*
   message TemplightHeader {
     required uint32 version = 1;
     optional string source_file = 2;
   }
     */
-    
+
     llvm::protobuf::saveVarInt(OS_inner, 1, 1); // version
-    if ( !aSourceName.empty() ) 
+    if (!aSourceName.empty())
       llvm::protobuf::saveString(OS_inner, 2, aSourceName); // source_file
   }
-  
+
   llvm::raw_string_ostream OS(buffer);
-  
+
   // required TemplightHeader header = 1;
   llvm::protobuf::saveString(OS, 1, hdr_contents);
-  
 }
 
 void TemplightProtobufWriter::finalize() {
@@ -55,9 +54,10 @@ void TemplightProtobufWriter::finalize() {
   llvm::protobuf::saveString(OutputOS, 1, buffer);
 }
 
-std::string TemplightProtobufWriter::printEntryLocation(
-    const std::string& FileName, int Line, int Column) {
-  
+std::string
+TemplightProtobufWriter::printEntryLocation(const std::string &FileName,
+                                            int Line, int Column) {
+
   /*
   message SourceLocation {
     optional string file_name = 1;
@@ -66,35 +66,36 @@ std::string TemplightProtobufWriter::printEntryLocation(
     optional uint32 column = 4;
   }
   */
-  
+
   std::string location_contents;
   llvm::raw_string_ostream OS_inner(location_contents);
-  
-  std::unordered_map< std::string, std::size_t >::iterator 
-    it = fileNameMap.find(FileName);
-  
-  if ( it == fileNameMap.end() ) {
+
+  std::unordered_map<std::string, std::size_t>::iterator it =
+      fileNameMap.find(FileName);
+
+  if (it == fileNameMap.end()) {
     llvm::protobuf::saveString(OS_inner, 1, FileName); // file_name
     std::size_t file_id = fileNameMap.size();
-    llvm::protobuf::saveVarInt(OS_inner, 2, file_id);     // file_id
+    llvm::protobuf::saveVarInt(OS_inner, 2, file_id); // file_id
     fileNameMap[FileName] = file_id;
   } else {
-    llvm::protobuf::saveVarInt(OS_inner, 2, it->second);     // file_id
+    llvm::protobuf::saveVarInt(OS_inner, 2, it->second); // file_id
   }
-  
-  llvm::protobuf::saveVarInt(OS_inner, 3, Line);     // line
-  llvm::protobuf::saveVarInt(OS_inner, 4, Column);   // column
-  
+
+  llvm::protobuf::saveVarInt(OS_inner, 3, Line);   // line
+  llvm::protobuf::saveVarInt(OS_inner, 4, Column); // column
+
   OS_inner.str();
-  
-  return location_contents;  // NRVO
+
+  return location_contents; // NRVO
 }
 
-static void trimSpaces(std::string::iterator& it, std::string::iterator& it_end) {
-  while ( it < it_end ) {
-    if ( *it == ' ' )
+static void trimSpaces(std::string::iterator &it,
+                       std::string::iterator &it_end) {
+  while (it < it_end) {
+    if (*it == ' ')
       ++it;
-    else if ( *it_end == ' ' )
+    else if (*it_end == ' ')
       --it_end;
     else
       break;
@@ -102,96 +103,101 @@ static void trimSpaces(std::string::iterator& it, std::string::iterator& it_end)
   ++it_end;
 }
 
-std::size_t TemplightProtobufWriter::createDictionaryEntry(const std::string& NameOrig) {
-  std::unordered_map< std::string, std::size_t >::iterator 
-    it_found = templateNameMap.find(NameOrig);
-  if ( it_found != templateNameMap.end() )
+std::size_t
+TemplightProtobufWriter::createDictionaryEntry(const std::string &NameOrig) {
+  std::unordered_map<std::string, std::size_t>::iterator it_found =
+      templateNameMap.find(NameOrig);
+  if (it_found != templateNameMap.end())
     return it_found->second;
-  
-  // FIXME: Convert this code to being constructive of "Name", instead of destructive (replacing sub-strings with '\0' characters).
+
+  // FIXME: Convert this code to being constructive of "Name", instead of
+  // destructive (replacing sub-strings with '\0' characters).
   std::string Name = NameOrig;
   std::string::iterator it_open = Name.end();
   std::string::iterator it_colon_lo = Name.begin();
   int srch_state = 0;
   llvm::SmallVector<std::size_t, 8> markers;
-  for(std::string::iterator it = Name.begin(); it != Name.end(); ++it) {
-    switch(srch_state) {
-      case 0: 
-        if ( *it == '<' ) {
-          // check for "operator<<", "operator<" and "operator<="
-          llvm::StringRef test_str(Name.data(), it - Name.begin() + 1);
-          if ( test_str.endswith("operator<") ) {
-            it_open = Name.end();
-            srch_state = 0;
-          } else {
-            it_open = it;
-            ++srch_state;
-          }
-        } else if ( (*it == ':') && (it + 1 < Name.end()) && (*(it+1) == ':') ) {
-          if ( it_colon_lo < it ) {
-            markers.push_back( createDictionaryEntry(std::string(it_colon_lo, it)) );
-            std::size_t offset_lo  = it_colon_lo - Name.begin();
-            Name.replace(it_colon_lo, it, 1, '\0');
-            it = Name.begin() + offset_lo + 2;
-          } else {
-            it += 1;
-          }
-          it_colon_lo = it + 1;
+  for (std::string::iterator it = Name.begin(); it != Name.end(); ++it) {
+    switch (srch_state) {
+    case 0:
+      if (*it == '<') {
+        // check for "operator<<", "operator<" and "operator<="
+        llvm::StringRef test_str(Name.data(), it - Name.begin() + 1);
+        if (test_str.endswith("operator<")) {
           it_open = Name.end();
-        }
-        break;
-      case 1:
-        if ( *it == '<' ) {
-          // check for "operator<<" and "operator<"
-          llvm::StringRef test_str(Name.data(), it - Name.begin() + 1);
-          if ( test_str.endswith("operator<<<") ) {
-            it_open = it;
-            srch_state = 1;
-          } else {
-            ++srch_state;
-          }
-        } else if ( ( *it == ',' ) || ( *it == '>' ) ) {
-          if ( it_colon_lo < it_open ) {
-            std::size_t offset_end = it - it_open;
-            std::size_t offset_lo  = it_colon_lo - Name.begin();
-            markers.push_back( createDictionaryEntry(std::string(it_colon_lo, it_open)) );
-            Name.replace(it_colon_lo, it_open, 1, '\0');
-            it_open = Name.begin() + offset_lo + 1;
-            it = it_open + offset_end;
-            it_colon_lo = Name.end();
-          }
-          std::string::iterator it_lo = it_open + 1;
-          std::string::iterator it_hi = it - 1;
-          trimSpaces(it_lo, it_hi);
-          // Create or find the marker entry:
-          markers.push_back( createDictionaryEntry(std::string(it_lo, it_hi)) );
-          std::size_t offset_end = it - it_hi;
-          std::size_t offset_lo  = it_lo - Name.begin();
-          Name.replace(it_lo, it_hi, 1, '\0');
-          it = Name.begin() + offset_lo + 1 + offset_end;
+          srch_state = 0;
+        } else {
           it_open = it;
-          it_colon_lo = Name.end();
-          if ( *it == '>' ) {
-            it_open = Name.end();
-            srch_state = 0;
-            it_colon_lo = it + 1;
-          }
-        }
-        break;
-      default:
-        if ( *it == '<' ) {
           ++srch_state;
-        } else if ( *it == '>' ) {
-          --srch_state;
         }
-        break;
+      } else if ((*it == ':') && (it + 1 < Name.end()) && (*(it + 1) == ':')) {
+        if (it_colon_lo < it) {
+          markers.push_back(
+              createDictionaryEntry(std::string(it_colon_lo, it)));
+          std::size_t offset_lo = it_colon_lo - Name.begin();
+          Name.replace(it_colon_lo, it, 1, '\0');
+          it = Name.begin() + offset_lo + 2;
+        } else {
+          it += 1;
+        }
+        it_colon_lo = it + 1;
+        it_open = Name.end();
+      }
+      break;
+    case 1:
+      if (*it == '<') {
+        // check for "operator<<" and "operator<"
+        llvm::StringRef test_str(Name.data(), it - Name.begin() + 1);
+        if (test_str.endswith("operator<<<")) {
+          it_open = it;
+          srch_state = 1;
+        } else {
+          ++srch_state;
+        }
+      } else if ((*it == ',') || (*it == '>')) {
+        if (it_colon_lo < it_open) {
+          std::size_t offset_end = it - it_open;
+          std::size_t offset_lo = it_colon_lo - Name.begin();
+          markers.push_back(
+              createDictionaryEntry(std::string(it_colon_lo, it_open)));
+          Name.replace(it_colon_lo, it_open, 1, '\0');
+          it_open = Name.begin() + offset_lo + 1;
+          it = it_open + offset_end;
+          it_colon_lo = Name.end();
+        }
+        std::string::iterator it_lo = it_open + 1;
+        std::string::iterator it_hi = it - 1;
+        trimSpaces(it_lo, it_hi);
+        // Create or find the marker entry:
+        markers.push_back(createDictionaryEntry(std::string(it_lo, it_hi)));
+        std::size_t offset_end = it - it_hi;
+        std::size_t offset_lo = it_lo - Name.begin();
+        Name.replace(it_lo, it_hi, 1, '\0');
+        it = Name.begin() + offset_lo + 1 + offset_end;
+        it_open = it;
+        it_colon_lo = Name.end();
+        if (*it == '>') {
+          it_open = Name.end();
+          srch_state = 0;
+          it_colon_lo = it + 1;
+        }
+      }
+      break;
+    default:
+      if (*it == '<') {
+        ++srch_state;
+      } else if (*it == '>') {
+        --srch_state;
+      }
+      break;
     }
   }
-  if ( !markers.empty() && it_colon_lo != Name.end() ) {
-    markers.push_back( createDictionaryEntry(std::string(it_colon_lo, Name.end())) );
+  if (!markers.empty() && it_colon_lo != Name.end()) {
+    markers.push_back(
+        createDictionaryEntry(std::string(it_colon_lo, Name.end())));
     Name.replace(it_colon_lo, Name.end(), 1, '\0');
   }
-  
+
   /*
   message DictionaryEntry {
     required string marked_name = 1;
@@ -201,68 +207,71 @@ std::size_t TemplightProtobufWriter::createDictionaryEntry(const std::string& Na
   std::string dict_entry;
   llvm::raw_string_ostream OS_dict(dict_entry);
   llvm::protobuf::saveString(OS_dict, 1, Name); // marked_name
-  for(llvm::SmallVector<std::size_t, 8>::iterator mk = markers.begin(),
-      mk_end = markers.end(); mk != mk_end; ++mk) {
+  for (llvm::SmallVector<std::size_t, 8>::iterator mk = markers.begin(),
+                                                   mk_end = markers.end();
+       mk != mk_end; ++mk) {
     llvm::protobuf::saveVarInt(OS_dict, 2, *mk); // marker_ids
   }
   OS_dict.str();
-  
+
   std::size_t id = templateNameMap.size();
   templateNameMap[NameOrig] = id;
-  
+
   llvm::raw_string_ostream OS_outer(buffer);
   // repeated DictionaryEntry names = 3;
   llvm::protobuf::saveString(OS_outer, 3, dict_entry);
-  
+
   return id;
 }
 
-std::string TemplightProtobufWriter::printTemplateName(const std::string& Name) {
-  
+std::string
+TemplightProtobufWriter::printTemplateName(const std::string &Name) {
+
   /*
   message TemplateName {
     optional string name = 1;
     optional bytes compressed_name = 2;
   }
   */
-  
+
   std::string tname_contents;
   llvm::raw_string_ostream OS_inner(tname_contents);
-  
-  switch( compressionMode ) {
-    case 1: { // zlib-compressed name:
-      llvm::SmallVector<char, 32> CompressedBuffer;
-      if ( llvm::zlib::compress(llvm::StringRef(Name), CompressedBuffer) ) {
-        // optional bytes compressed_name = 2;
-        llvm::protobuf::saveString(OS_inner, 2, 
+
+  switch (compressionMode) {
+  case 1: { // zlib-compressed name:
+    llvm::SmallVector<char, 32> CompressedBuffer;
+    if (llvm::zlib::compress(llvm::StringRef(Name), CompressedBuffer)) {
+      // optional bytes compressed_name = 2;
+      llvm::protobuf::saveString(
+          OS_inner, 2,
           llvm::StringRef(CompressedBuffer.begin(), CompressedBuffer.size()));
-        break;
-      } // else, go to case 0:
-    }
-    LLVM_FALLTHROUGH;
-    case 0:
-      // optional string name = 1;
-      llvm::protobuf::saveString(OS_inner, 1, Name); // name
       break;
-    case 2:
-    default:
-      // optional uint32 dict_id = 3;
-      llvm::protobuf::saveVarInt(OS_inner, 3, 
-        createDictionaryEntry(Name));
-      break;
+    } // else, go to case 0:
   }
-  
+    LLVM_FALLTHROUGH;
+  case 0:
+    // optional string name = 1;
+    llvm::protobuf::saveString(OS_inner, 1, Name); // name
+    break;
+  case 2:
+  default:
+    // optional uint32 dict_id = 3;
+    llvm::protobuf::saveVarInt(OS_inner, 3, createDictionaryEntry(Name));
+    break;
+  }
+
   OS_inner.str();
-  
-  return tname_contents;  // NRVO
+
+  return tname_contents; // NRVO
 }
 
-void TemplightProtobufWriter::printEntry(const PrintableTemplightEntryBegin& aEntry) {
-  
+void TemplightProtobufWriter::printEntry(
+    const PrintableTemplightEntryBegin &aEntry) {
+
   std::string entry_contents;
   {
     llvm::raw_string_ostream OS_inner(entry_contents);
-    
+
     /*
   message Begin {
     required SynthesisKind kind = 1;
@@ -273,88 +282,82 @@ void TemplightProtobufWriter::printEntry(const PrintableTemplightEntryBegin& aEn
     optional SourceLocation template_origin = 6;
   }
     */
-    
-    llvm::protobuf::saveVarInt(OS_inner, 1, aEntry.SynthesisKind);    // kind
-    llvm::protobuf::saveString(OS_inner, 2, 
-                         printTemplateName(aEntry.Name));                 // name
-    llvm::protobuf::saveString(OS_inner, 3, 
-                               printEntryLocation(aEntry.FileName, 
-                                                  aEntry.Line, 
+
+    llvm::protobuf::saveVarInt(OS_inner, 1, aEntry.SynthesisKind); // kind
+    llvm::protobuf::saveString(OS_inner, 2,
+                               printTemplateName(aEntry.Name)); // name
+    llvm::protobuf::saveString(OS_inner, 3,
+                               printEntryLocation(aEntry.FileName, aEntry.Line,
                                                   aEntry.Column)); // location
-    llvm::protobuf::saveDouble(OS_inner, 4, aEntry.TimeStamp);            // time_stamp
-    if ( aEntry.MemoryUsage > 0 )
-      llvm::protobuf::saveVarInt(OS_inner, 5, aEntry.MemoryUsage);        // memory_usage
-    if ( !aEntry.TempOri_FileName.empty() )
-      llvm::protobuf::saveString(OS_inner, 6, 
-                                 printEntryLocation(aEntry.TempOri_FileName, 
-                                                    aEntry.TempOri_Line, 
-                                                    aEntry.TempOri_Column)); // template_origin
+    llvm::protobuf::saveDouble(OS_inner, 4, aEntry.TimeStamp);     // time_stamp
+    if (aEntry.MemoryUsage > 0)
+      llvm::protobuf::saveVarInt(OS_inner, 5,
+                                 aEntry.MemoryUsage); // memory_usage
+    if (!aEntry.TempOri_FileName.empty())
+      llvm::protobuf::saveString(
+          OS_inner, 6,
+          printEntryLocation(aEntry.TempOri_FileName, aEntry.TempOri_Line,
+                             aEntry.TempOri_Column)); // template_origin
   }
-  
+
   std::string oneof_contents;
   {
     llvm::raw_string_ostream OS_inner(oneof_contents);
-    
+
     /*
   oneof begin_or_end {
     Begin begin = 1;
     End end = 2;
-  } 
-     */
-    
-    llvm::protobuf::saveString(OS_inner, 1, entry_contents); // begin
-    
   }
-  
+     */
+
+    llvm::protobuf::saveString(OS_inner, 1, entry_contents); // begin
+  }
+
   llvm::raw_string_ostream OS(buffer);
-  
+
   // repeated TemplightEntry entries = 2;
   llvm::protobuf::saveString(OS, 2, oneof_contents);
-  
 }
 
-void TemplightProtobufWriter::printEntry(const PrintableTemplightEntryEnd& aEntry) {
-  
+void TemplightProtobufWriter::printEntry(
+    const PrintableTemplightEntryEnd &aEntry) {
+
   std::string entry_contents;
   {
     llvm::raw_string_ostream OS_inner(entry_contents);
-    
+
     /*
   message End {
     optional double time_stamp = 1;
     optional uint64 memory_usage = 2;
   }
     */
-    
-    llvm::protobuf::saveDouble(OS_inner, 1, aEntry.TimeStamp);     // time_stamp
-    if ( aEntry.MemoryUsage > 0 )
-      llvm::protobuf::saveVarInt(OS_inner, 2, aEntry.MemoryUsage); // memory_usage
-    
+
+    llvm::protobuf::saveDouble(OS_inner, 1, aEntry.TimeStamp); // time_stamp
+    if (aEntry.MemoryUsage > 0)
+      llvm::protobuf::saveVarInt(OS_inner, 2,
+                                 aEntry.MemoryUsage); // memory_usage
   }
-  
+
   std::string oneof_contents;
   {
     llvm::raw_string_ostream OS_inner(oneof_contents);
-    
+
     /*
   oneof begin_or_end {
     Begin begin = 1;
     End end = 2;
-  } 
-     */
-    
-    llvm::protobuf::saveString(OS_inner, 2, entry_contents); // end
-    
   }
-  
+     */
+
+    llvm::protobuf::saveString(OS_inner, 2, entry_contents); // end
+  }
+
   llvm::raw_string_ostream OS(buffer);
-  
+
   // repeated TemplightEntry entries = 2;
   llvm::protobuf::saveString(OS, 2, oneof_contents);
-  
 }
 
-
-
 } // namespace clang
-

--- a/lib/TemplightTracer.cpp
+++ b/lib/TemplightTracer.cpp
@@ -1,4 +1,4 @@
-//===- TemplightTracer.cpp ------ Clang Templight Profiler / Tracer -*- C++ -*-===//
+//===- TemplightTracer.cpp -----------------------*- C++ -*----------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -9,29 +9,28 @@
 
 #include "TemplightTracer.h"
 
-#include "TemplightProtobufWriter.h"
 #include "PrintableTemplightEntries.h"
 #include "TemplightEntryPrinter.h"
+#include "TemplightProtobufWriter.h"
 
 #include <clang/Basic/FileManager.h>
 #include <clang/Basic/SourceManager.h>
 #include <clang/Sema/Sema.h>
 
-#include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/Format.h>
-#include <llvm/Support/Timer.h>
 #include <llvm/Support/Process.h>
+#include <llvm/Support/Timer.h>
 #include <llvm/Support/YAMLTraits.h>
+#include <llvm/Support/raw_ostream.h>
 
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include <cstdint>
 
 namespace clang {
 
 namespace {
-
 
 struct RawTemplightTraceEntry {
   bool IsTemplateBegin;
@@ -41,26 +40,29 @@ struct RawTemplightTraceEntry {
   SourceLocation PointOfInstantiation;
   double TimeStamp;
   std::uint64_t MemoryUsage;
-  
+
   static const std::size_t invalid_parent = ~std::size_t(0);
-  
-  RawTemplightTraceEntry() : IsTemplateBegin(true), ParentBeginIdx(invalid_parent),
-    SynthesisKind(Sema::CodeSynthesisContext::TemplateInstantiation),
-    Entity(0), TimeStamp(0.0), MemoryUsage(0) { };
+
+  RawTemplightTraceEntry()
+      : IsTemplateBegin(true), ParentBeginIdx(invalid_parent),
+        SynthesisKind(Sema::CodeSynthesisContext::TemplateInstantiation),
+        Entity(0), TimeStamp(0.0), MemoryUsage(0){};
 };
 
-PrintableTemplightEntryBegin rawToPrintableBegin(const Sema &TheSema, const RawTemplightTraceEntry& Entry) {
+PrintableTemplightEntryBegin
+rawToPrintableBegin(const Sema &TheSema, const RawTemplightTraceEntry &Entry) {
   PrintableTemplightEntryBegin Ret;
-  
+
   Ret.SynthesisKind = Entry.SynthesisKind;
-  
+
   NamedDecl *NamedTemplate = dyn_cast_or_null<NamedDecl>(Entry.Entity);
   if (NamedTemplate) {
     llvm::raw_string_ostream OS(Ret.Name);
     NamedTemplate->getNameForDiagnostic(OS, TheSema.getLangOpts(), true);
   }
-  
-  PresumedLoc Loc = TheSema.getSourceManager().getPresumedLoc(Entry.PointOfInstantiation);
+
+  PresumedLoc Loc =
+      TheSema.getSourceManager().getPresumedLoc(Entry.PointOfInstantiation);
   if (!Loc.isInvalid()) {
     Ret.FileName = Loc.getFilename();
     Ret.Line = Loc.getLine();
@@ -70,12 +72,13 @@ PrintableTemplightEntryBegin rawToPrintableBegin(const Sema &TheSema, const RawT
     Ret.Line = 0;
     Ret.Column = 0;
   }
-  
+
   Ret.TimeStamp = Entry.TimeStamp;
   Ret.MemoryUsage = Entry.MemoryUsage;
-  
+
   if (Entry.Entity) {
-    PresumedLoc Loc = TheSema.getSourceManager().getPresumedLoc(Entry.Entity->getLocation());
+    PresumedLoc Loc =
+        TheSema.getSourceManager().getPresumedLoc(Entry.Entity->getLocation());
     if (!Loc.isInvalid()) {
       Ret.TempOri_FileName = Loc.getFilename();
       Ret.TempOri_Line = Loc.getLine();
@@ -86,96 +89,102 @@ PrintableTemplightEntryBegin rawToPrintableBegin(const Sema &TheSema, const RawT
       Ret.TempOri_Column = 0;
     }
   }
-  
+
   return Ret;
 }
 
-PrintableTemplightEntryEnd rawToPrintableEnd(const Sema &TheSema, const RawTemplightTraceEntry& Entry) {
+PrintableTemplightEntryEnd
+rawToPrintableEnd(const Sema &TheSema, const RawTemplightTraceEntry &Entry) {
   return {Entry.TimeStamp, Entry.MemoryUsage};
 }
 
 } // unnamed namespace
 
-
-
 class TemplightTracer::TracePrinter : public TemplightEntryPrinter {
 public:
-  
-  void skipRawEntry(const RawTemplightTraceEntry &Entry) {
-    skipEntry();
-  }
-  
+  void skipRawEntry(const RawTemplightTraceEntry &Entry) { skipEntry(); }
+
   bool shouldIgnoreRawEntry(const RawTemplightTraceEntry &Entry) {
-    
+
     // Avoid some duplication of memoization entries:
-    if ( ( Entry.SynthesisKind == Sema::CodeSynthesisContext::Memoization ) &&
-          LastClosedMemoization && ( LastClosedMemoization == Entry.Entity ) ) {
+    if ((Entry.SynthesisKind == Sema::CodeSynthesisContext::Memoization) &&
+        LastClosedMemoization && (LastClosedMemoization == Entry.Entity)) {
       return true;
     }
-    
-    // if we have an end entry, we must ensure it corresponds to the current begin entry:
-    //  these checks are a bit redundant and overly cautious, but better safe than sorry when sanitizing.
-    if ( (!Entry.IsTemplateBegin) &&
-         ( ( TraceEntries.empty() ) || 
-           ( CurrentParentBegin == RawTemplightTraceEntry::invalid_parent ) || 
-           ( CurrentParentBegin >= TraceEntries.size() ) ||
-           !( ( TraceEntries[CurrentParentBegin].SynthesisKind == Entry.SynthesisKind ) &&
-              ( TraceEntries[CurrentParentBegin].Entity == Entry.Entity ) ) ) ) {
-      return true; // ignore end entries that don't match the current begin entry.
+
+    // if we have an end entry, we must ensure it corresponds to the current
+    // begin entry:
+    //  these checks are a bit redundant and overly cautious, but better safe
+    //  than sorry when sanitizing.
+    if ((!Entry.IsTemplateBegin) &&
+        ((TraceEntries.empty()) ||
+         (CurrentParentBegin == RawTemplightTraceEntry::invalid_parent) ||
+         (CurrentParentBegin >= TraceEntries.size()) ||
+         !((TraceEntries[CurrentParentBegin].SynthesisKind ==
+            Entry.SynthesisKind) &&
+           (TraceEntries[CurrentParentBegin].Entity == Entry.Entity)))) {
+      return true; // ignore end entries that don't match the current begin
+                   // entry.
     }
-    
+
     return false;
   };
-  
+
   void printOrSkipEntry(RawTemplightTraceEntry &Entry) {
-    if ( IgnoreSystemFlag && !Entry.PointOfInstantiation.isInvalid() && 
-         TheSema.getSourceManager()
-           .isInSystemHeader(Entry.PointOfInstantiation) ) {
-      skipRawEntry(Entry); // recursively skip all entries until end of this one.
+    if (IgnoreSystemFlag && !Entry.PointOfInstantiation.isInvalid() &&
+        TheSema.getSourceManager().isInSystemHeader(
+            Entry.PointOfInstantiation)) {
+      skipRawEntry(
+          Entry); // recursively skip all entries until end of this one.
     } else {
-      if ( Entry.IsTemplateBegin ) {
+      if (Entry.IsTemplateBegin) {
         printEntry(rawToPrintableBegin(TheSema, Entry));
       } else {
         printEntry(rawToPrintableEnd(TheSema, Entry));
       }
     }
   };
-  
+
   void printCachedRawEntries() {
-    for(std::vector<RawTemplightTraceEntry>::iterator it = TraceEntries.begin();
-        it != TraceEntries.end(); ++it)
+    for (std::vector<RawTemplightTraceEntry>::iterator it =
+             TraceEntries.begin();
+         it != TraceEntries.end(); ++it)
       printOrSkipEntry(*it);
     TraceEntries.clear();
     CurrentParentBegin = RawTemplightTraceEntry::invalid_parent;
   };
-  
+
   void printRawEntry(RawTemplightTraceEntry Entry, bool inSafeMode = false) {
-    if ( shouldIgnoreRawEntry(Entry) )
+    if (shouldIgnoreRawEntry(Entry))
       return;
-    
-    if ( inSafeMode )
+
+    if (inSafeMode)
       printOrSkipEntry(Entry);
-    
-    // Always maintain a stack of cached trace entries such that the sanity of the traces can be enforced.
-    if ( Entry.IsTemplateBegin ) {
+
+    // Always maintain a stack of cached trace entries such that the sanity of
+    // the traces can be enforced.
+    if (Entry.IsTemplateBegin) {
       Entry.ParentBeginIdx = CurrentParentBegin;
       CurrentParentBegin = TraceEntries.size();
-    } else { // note: this point should not be reached if CurrentParentBegin is not valid.
+    } else { // note: this point should not be reached if CurrentParentBegin is
+             // not valid.
       Entry.ParentBeginIdx = TraceEntries[CurrentParentBegin].ParentBeginIdx;
       CurrentParentBegin = Entry.ParentBeginIdx;
     };
-    TraceEntries.push_back(Entry); 
-    
-    if ( Entry.IsTemplateBegin )
+    TraceEntries.push_back(Entry);
+
+    if (Entry.IsTemplateBegin)
       LastClosedMemoization = nullptr;
-    if ( !Entry.IsTemplateBegin && 
-         ( Entry.SynthesisKind == Sema::CodeSynthesisContext::Memoization ) )
+    if (!Entry.IsTemplateBegin &&
+        (Entry.SynthesisKind == Sema::CodeSynthesisContext::Memoization))
       LastClosedMemoization = Entry.Entity;
-    
-    if ( !Entry.IsTemplateBegin &&
-         ( Entry.SynthesisKind == TraceEntries.front().SynthesisKind ) &&
-         ( Entry.Entity == TraceEntries.front().Entity ) ) {  // did we reach the end of the top-level begin entry?
-      if ( !inSafeMode ) { // if not in safe-mode, print out the cached entries.
+
+    if (!Entry.IsTemplateBegin &&
+        (Entry.SynthesisKind == TraceEntries.front().SynthesisKind) &&
+        (Entry.Entity ==
+         TraceEntries.front()
+             .Entity)) { // did we reach the end of the top-level begin entry?
+      if (!inSafeMode) { // if not in safe-mode, print out the cached entries.
         printCachedRawEntries();
       } else { // if in safe-mode, simply clear the cached entries.
         TraceEntries.clear();
@@ -183,129 +192,125 @@ public:
       }
     }
   };
-  
+
   void startTrace() {
     // get the source name from the source manager:
     FileID fileID = TheSema.getSourceManager().getMainFileID();
     std::string src_name =
-      TheSema.getSourceManager().getFileEntryForID(fileID)->getName();
+        TheSema.getSourceManager().getFileEntryForID(fileID)->getName();
     initialize(src_name);
   };
-  
+
   void endTrace() {
     printCachedRawEntries();
     finalize();
   };
-  
-  TracePrinter(const Sema &aSema, const std::string &Output, bool IgnoreSystem = false) : 
-               TemplightEntryPrinter(Output), TheSema(aSema), 
-               LastClosedMemoization(nullptr), 
-               CurrentParentBegin(RawTemplightTraceEntry::invalid_parent), 
-               IgnoreSystemFlag(IgnoreSystem) { };
-  
-  ~TracePrinter() { };
-  
+
+  TracePrinter(const Sema &aSema, const std::string &Output,
+               bool IgnoreSystem = false)
+      : TemplightEntryPrinter(Output), TheSema(aSema),
+        LastClosedMemoization(nullptr),
+        CurrentParentBegin(RawTemplightTraceEntry::invalid_parent),
+        IgnoreSystemFlag(IgnoreSystem){};
+
+  ~TracePrinter(){};
+
   const Sema &TheSema;
-  
+
   std::vector<RawTemplightTraceEntry> TraceEntries;
-  Decl* LastClosedMemoization;
+  Decl *LastClosedMemoization;
   std::size_t CurrentParentBegin;
-  
+
   unsigned IgnoreSystemFlag : 1;
-  
 };
 
-
 void TemplightTracer::atTemplateBegin(const Sema &TheSema,
-                          const Sema::CodeSynthesisContext& Inst) {
-  if ( !Printer )
+                                      const Sema::CodeSynthesisContext &Inst) {
+  if (!Printer)
     return;
-  
+
   RawTemplightTraceEntry Entry;
-  
+
   Entry.IsTemplateBegin = true;
   Entry.SynthesisKind = Inst.Kind;
   Entry.Entity = Inst.Entity;
   Entry.PointOfInstantiation = Inst.PointOfInstantiation;
-  
+
   // NOTE: Use this function because it produces time since start of process.
   llvm::sys::TimePoint<> now;
   std::chrono::nanoseconds user, sys;
   llvm::sys::Process::GetTimeUsage(now, user, sys);
-  if(user != std::chrono::nanoseconds::zero())
+  if (user != std::chrono::nanoseconds::zero())
     now = llvm::sys::TimePoint<>(user);
-  
+
   using Seconds = std::chrono::duration<double, std::ratio<1>>;
   Entry.TimeStamp = Seconds(now.time_since_epoch()).count();
   Entry.MemoryUsage = (MemoryFlag ? llvm::sys::Process::GetMallocUsage() : 0);
-  
+
   Printer->printRawEntry(Entry, SafeModeFlag);
 }
 
 void TemplightTracer::atTemplateEnd(const Sema &TheSema,
-                          const Sema::CodeSynthesisContext& Inst) {
-  if ( !Printer )
+                                    const Sema::CodeSynthesisContext &Inst) {
+  if (!Printer)
     return;
-  
+
   RawTemplightTraceEntry Entry;
-  
+
   Entry.IsTemplateBegin = false;
   Entry.SynthesisKind = Inst.Kind;
   Entry.Entity = Inst.Entity;
-  
+
   // NOTE: Use this function because it produces time since start of process.
   llvm::sys::TimePoint<> now;
   std::chrono::nanoseconds user, sys;
   llvm::sys::Process::GetTimeUsage(now, user, sys);
-  if(user != std::chrono::nanoseconds::zero())
+  if (user != std::chrono::nanoseconds::zero())
     now = llvm::sys::TimePoint<>(user);
-  
+
   using Seconds = std::chrono::duration<double, std::ratio<1>>;
   Entry.TimeStamp = Seconds(now.time_since_epoch()).count();
   Entry.MemoryUsage = (MemoryFlag ? llvm::sys::Process::GetMallocUsage() : 0);
-  
+
   Printer->printRawEntry(Entry, SafeModeFlag);
 }
 
-TemplightTracer::TemplightTracer(const Sema &TheSema,
-                                 std::string Output, 
-                                 bool Memory, bool Safemode, 
-                                 bool IgnoreSystem) :
-                                 MemoryFlag(Memory),
-                                 SafeModeFlag(Safemode) {
-  
-  Printer.reset(new TemplightTracer::TracePrinter(TheSema, Output, IgnoreSystem));
-  
-  if ( !Printer->getTraceStream() ) {
-    llvm::errs() << "Error: [Templight-Tracer] Failed to create template trace file!";
+TemplightTracer::TemplightTracer(const Sema &TheSema, std::string Output,
+                                 bool Memory, bool Safemode, bool IgnoreSystem)
+    : MemoryFlag(Memory), SafeModeFlag(Safemode) {
+
+  Printer.reset(
+      new TemplightTracer::TracePrinter(TheSema, Output, IgnoreSystem));
+
+  if (!Printer->getTraceStream()) {
+    llvm::errs()
+        << "Error: [Templight-Tracer] Failed to create template trace file!";
     Printer.reset();
     llvm::errs() << "Note: [Templight] Template trace has been disabled.";
     return;
   }
-  
-  Printer->takeWriter(new clang::TemplightProtobufWriter(*Printer->getTraceStream()));
-  
+
+  Printer->takeWriter(
+      new clang::TemplightProtobufWriter(*Printer->getTraceStream()));
 }
 
-TemplightTracer::~TemplightTracer() { 
+TemplightTracer::~TemplightTracer() {
   // must be defined here due to TracePrinter being incomplete in header.
 }
 
 void TemplightTracer::initialize(const Sema &) {
-  if ( Printer )
+  if (Printer)
     Printer->startTrace();
 }
 
 void TemplightTracer::finalize(const Sema &) {
-  if ( Printer )
+  if (Printer)
     Printer->endTrace();
 }
 
-void TemplightTracer::readBlacklists(const std::string& BLFilename) {
-  if ( Printer )
+void TemplightTracer::readBlacklists(const std::string &BLFilename) {
+  if (Printer)
     Printer->readBlacklists(BLFilename);
 }
 
-
 } // namespace clang
-

--- a/templight_driver.cpp
+++ b/templight_driver.cpp
@@ -1,4 +1,4 @@
-//===-- templight_driver.cpp - Clang GCC-Compatible Driver --------------------------===//
+//===-- templight_driver.cpp ------------------------------*- C++ -*-------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -8,7 +8,8 @@
 //===----------------------------------------------------------------------===//
 //
 // This is the entry point to the templight driver; it is a thin wrapper
-// for functionality in the Driver clang library with modifications to invoke Templight.
+// for functionality in the Driver clang library with modifications to invoke
+// Templight.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,10 +21,10 @@
 #include "clang/Driver/DriverDiagnostic.h"
 #include "clang/Driver/Options.h"
 #include "clang/Driver/Tool.h"
-#include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/ChainedDiagnosticConsumer.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
-#include "clang/Frontend/FrontendDiagnostic.h"  // IWYU pragma: keep
+#include "clang/Frontend/FrontendDiagnostic.h" // IWYU pragma: keep
 #include "clang/Frontend/SerializedDiagnosticPrinter.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Frontend/Utils.h"
@@ -60,8 +61,8 @@
 
 #include "TemplightAction.h"
 
-#include <set>
 #include <memory>
+#include <set>
 #include <system_error>
 
 using namespace clang;
@@ -69,63 +70,66 @@ using namespace clang::driver;
 using namespace llvm::opt;
 using namespace llvm;
 
+// Mark all Templight options with this category, everything else will be
+// handled as clang driver options.
+static cl::OptionCategory
+    ClangTemplightCategory("Templight options (USAGE: templight [[-Xtemplight "
+                           "[templight option]]|[options]] <inputs>)");
 
+static cl::opt<bool> OutputToStdOut(
+    "stdout",
+    cl::desc("Output template instantiation traces to standard output."),
+    cl::cat(ClangTemplightCategory));
 
-// Mark all Templight options with this category, everything else will be handled as clang driver options.
-static cl::OptionCategory ClangTemplightCategory("Templight options (USAGE: templight [[-Xtemplight [templight option]]|[options]] <inputs>)");
+static cl::opt<bool> MemoryProfile(
+    "memory",
+    cl::desc("Profile the memory usage during template instantiations."),
+    cl::cat(ClangTemplightCategory));
 
-static cl::opt<bool> OutputToStdOut("stdout",
-  cl::desc("Output template instantiation traces to standard output."),
-  cl::cat(ClangTemplightCategory));
+static cl::opt<bool> OutputInSafeMode(
+    "safe-mode",
+    cl::desc("Output Templight traces without buffering, \n"
+             "not to lose them at failure (note: this will \n"
+             "distort the timing profiles due to file I/O latency)."),
+    cl::cat(ClangTemplightCategory));
 
-static cl::opt<bool> MemoryProfile("memory",
-  cl::desc("Profile the memory usage during template instantiations."),
-  cl::cat(ClangTemplightCategory));
+static cl::opt<bool>
+    IgnoreSystemInst("ignore-system",
+                     cl::desc("Ignore any template instantiation coming from \n"
+                              "system-includes (-isystem)."),
+                     cl::cat(ClangTemplightCategory));
 
-static cl::opt<bool> OutputInSafeMode("safe-mode",
-  cl::desc("Output Templight traces without buffering, \n"
-           "not to lose them at failure (note: this will \n"
-           "distort the timing profiles due to file I/O latency)."),
-  cl::cat(ClangTemplightCategory));
+static cl::opt<bool>
+    InstProfiler("profiler",
+                 cl::desc("Start an interactive Templight debugging session."),
+                 cl::cat(ClangTemplightCategory));
 
-static cl::opt<bool> IgnoreSystemInst("ignore-system",
-  cl::desc("Ignore any template instantiation coming from \n"
-           "system-includes (-isystem)."),
-  cl::cat(ClangTemplightCategory));
+static cl::opt<bool> InteractiveDebug(
+    "debugger", cl::desc("Start an interactive Templight debugging session."),
+    cl::cat(ClangTemplightCategory));
 
-static cl::opt<bool> InstProfiler("profiler",
-  cl::desc("Start an interactive Templight debugging session."),
-  cl::cat(ClangTemplightCategory));
-
-static cl::opt<bool> InteractiveDebug("debugger",
-  cl::desc("Start an interactive Templight debugging session."),
-  cl::cat(ClangTemplightCategory));
-
-static cl::opt<std::string> OutputFilename("output",
-  cl::desc("Write Templight profiling traces to <file>."),
-  cl::cat(ClangTemplightCategory));
+static cl::opt<std::string>
+    OutputFilename("output",
+                   cl::desc("Write Templight profiling traces to <file>."),
+                   cl::cat(ClangTemplightCategory));
 
 static std::string LocalOutputFilename;
 static SmallVector<std::string, 32> TempOutputFiles;
 
-static cl::opt<std::string> BlackListFilename("blacklist",
-  cl::desc("Use regex expressions in <file> to filter out undesirable traces."),
-  cl::cat(ClangTemplightCategory));
+static cl::opt<std::string> BlackListFilename(
+    "blacklist",
+    cl::desc(
+        "Use regex expressions in <file> to filter out undesirable traces."),
+    cl::cat(ClangTemplightCategory));
 
-
-static cl::Option* TemplightOptions[] = {
-    &OutputToStdOut,
-    &MemoryProfile,
-    &OutputInSafeMode,
-    &IgnoreSystemInst,
-    &InstProfiler,
-    &InteractiveDebug,
-    &OutputFilename,
-    &BlackListFilename};
+static cl::Option *TemplightOptions[] = {
+    &OutputToStdOut, &MemoryProfile,    &OutputInSafeMode, &IgnoreSystemInst,
+    &InstProfiler,   &InteractiveDebug, &OutputFilename,   &BlackListFilename};
 
 void PrintTemplightHelp() {
   // Compute the maximum argument length...
-  const std::size_t TemplightOptNum = sizeof(TemplightOptions) / sizeof(cl::Option*);
+  const std::size_t TemplightOptNum =
+      sizeof(TemplightOptions) / sizeof(cl::Option *);
   std::size_t MaxArgLen = 0;
   for (std::size_t i = 0, e = TemplightOptNum; i != e; ++i)
     MaxArgLen = std::max(MaxArgLen, TemplightOptions[i]->getOptionWidth());
@@ -143,7 +147,7 @@ std::string GetExecutablePath(const char *Argv0, bool CanonicalPrefixes) {
 
   // This just needs to be some symbol in the binary; C++ doesn't
   // allow taking the address of ::main however.
-  void *P = (void*) (intptr_t) GetExecutablePath;
+  void *P = (void *)(intptr_t)GetExecutablePath;
   return llvm::sys::fs::getMainExecutable(Argv0, P);
 }
 
@@ -222,7 +226,7 @@ static const DriverSuffix *parseDriverSuffix(StringRef ProgName) {
     ProgName = ProgName.slice(0, ProgName.rfind('-'));
     DS = FindDriverSuffix(ProgName);
   }
-   return DS;
+  return DS;
 }
 
 static void insertArgsFromProgramName(StringRef ProgName,
@@ -240,8 +244,8 @@ static void insertArgsFromProgramName(StringRef ProgName,
     ArgVector.insert(it, Flag);
   }
 
-  StringRef::size_type LastComponent = ProgName.rfind(
-      '-', ProgName.size() - strlen(DS->Suffix));
+  StringRef::size_type LastComponent =
+      ProgName.rfind('-', ProgName.size() - strlen(DS->Suffix));
   if (LastComponent == StringRef::npos)
     return;
 
@@ -252,7 +256,7 @@ static void insertArgsFromProgramName(StringRef ProgName,
     auto it = ArgVector.begin();
     if (it != ArgVector.end())
       ++it;
-    const char *arr[] = { "-target", GetStableCStr(SavedStrings, Prefix) };
+    const char *arr[] = {"-target", GetStableCStr(SavedStrings, Prefix)};
     ArgVector.insert(it, std::begin(arr), std::end(arr));
   }
 }
@@ -276,8 +280,9 @@ static void SetBackdoorDriverOutputsFromEnvVars(Driver &TheDriver) {
 
 static void FixupDiagPrefixExeName(TextDiagnosticPrinter *DiagClient,
                                    const std::string &Path) {
-  // If the templight binary happens to be named cl.exe for compatibility reasons,
-  // use templight-cl.exe as the prefix to avoid confusion between templight and MSVC.
+  // If the templight binary happens to be named cl.exe for compatibility
+  // reasons, use templight-cl.exe as the prefix to avoid confusion between
+  // templight and MSVC.
   StringRef ExeBasename(llvm::sys::path::filename(Path));
   if (ExeBasename.equals_lower("cl.exe"))
     ExeBasename = "templight-cl.exe";
@@ -292,11 +297,12 @@ CreateAndPopulateDiagOpts(SmallVectorImpl<const char *> &argv) {
   std::unique_ptr<OptTable> Opts(createDriverOptTable());
   unsigned MissingArgIndex, MissingArgCount;
   InputArgList Args(Opts->ParseArgs(
-      llvm::ArrayRef<const char*>(argv.begin() + 1, argv.end()), MissingArgIndex, MissingArgCount));
+      llvm::ArrayRef<const char *>(argv.begin() + 1, argv.end()),
+      MissingArgIndex, MissingArgCount));
   // We ignore MissingArgCount and the return value of ParseDiagnosticArgs.
   // Any errors that would be diagnosed here will also be diagnosed later,
   // when the DiagnosticsEngine actually exists.
-  (void) ParseDiagnosticArgs(*DiagOpts, Args);
+  (void)ParseDiagnosticArgs(*DiagOpts, Args);
   return DiagOpts;
 }
 
@@ -310,7 +316,8 @@ static void SetInstallDir(SmallVectorImpl<const char *> &argv,
   // Do a PATH lookup, if there are no directory components.
   if (llvm::sys::path::filename(InstalledPath) == InstalledPath) {
     std::string Tmp = llvm::sys::findProgramByName(
-      llvm::sys::path::filename(InstalledPath.str())).get();
+                          llvm::sys::path::filename(InstalledPath.str()))
+                          .get();
     if (!Tmp.empty())
       InstalledPath = Tmp;
   }
@@ -320,17 +327,16 @@ static void SetInstallDir(SmallVectorImpl<const char *> &argv,
     TheDriver.setInstalledDir(InstalledPath);
 }
 
-
-static
-int ExecuteTemplightInvocation(CompilerInstance *Clang) {
+static int ExecuteTemplightInvocation(CompilerInstance *Clang) {
   // Honor -help.
   if (Clang->getFrontendOpts().ShowHelp) {
 
     // Print the help for the general clang options:
     std::unique_ptr<OptTable> Opts(driver::createDriverOptTable());
     Opts->PrintHelp(llvm::outs(), "templight",
-                    "Template Profiler and Debugger based on LLVM 'Clang' Compiler: http://clang.llvm.org",
-                    /*Include=*/ driver::options::CC1Option, /*Exclude=*/ 0);
+                    "Template Profiler and Debugger based on LLVM 'Clang' "
+                    "Compiler: http://clang.llvm.org",
+                    /*Include=*/driver::options::CC1Option, /*Exclude=*/0);
 
     return 0;
   }
@@ -344,13 +350,13 @@ int ExecuteTemplightInvocation(CompilerInstance *Clang) {
   }
 
   // Load any requested plugins.
-  for (unsigned i = 0,
-         e = Clang->getFrontendOpts().Plugins.size(); i != e; ++i) {
+  for (unsigned i = 0, e = Clang->getFrontendOpts().Plugins.size(); i != e;
+       ++i) {
     const std::string &Path = Clang->getFrontendOpts().Plugins[i];
     std::string Error;
     if (llvm::sys::DynamicLibrary::LoadLibraryPermanently(Path.c_str(), &Error))
       Clang->getDiagnostics().Report(diag::err_fe_unable_to_load_plugin)
-        << Path << Error;
+          << Path << Error;
   }
 
   // Honor -mllvm.
@@ -359,7 +365,7 @@ int ExecuteTemplightInvocation(CompilerInstance *Clang) {
   // This should happen AFTER plugins have been loaded!
   if (!Clang->getFrontendOpts().LLVMArgs.empty()) {
     unsigned NumArgs = Clang->getFrontendOpts().LLVMArgs.size();
-    auto Args = llvm::make_unique<const char*[]>(NumArgs + 2);
+    auto Args = llvm::make_unique<const char *[]>(NumArgs + 2);
     Args[0] = "clang (LLVM option parsing)";
     for (unsigned i = 0; i != NumArgs; ++i)
       Args[i + 1] = Clang->getFrontendOpts().LLVMArgs[i].c_str();
@@ -380,7 +386,8 @@ int ExecuteTemplightInvocation(CompilerInstance *Clang) {
     return 1;
 
   // Create and execute the frontend action.
-  std::unique_ptr<TemplightAction> Act(new TemplightAction(CreateFrontendAction(*Clang)));
+  std::unique_ptr<TemplightAction> Act(
+      new TemplightAction(CreateFrontendAction(*Clang)));
   if (!Act)
     return 1;
 
@@ -394,8 +401,7 @@ int ExecuteTemplightInvocation(CompilerInstance *Clang) {
   Act->BlackListFilename = BlackListFilename;
 
   Act->OutputFilename = TemplightAction::CreateOutputFilename(
-    Clang, LocalOutputFilename,
-    InstProfiler, OutputToStdOut, MemoryProfile);
+      Clang, LocalOutputFilename, InstProfiler, OutputToStdOut, MemoryProfile);
 
   // Executing the templight action...
   bool Success = Clang->ExecuteAction(*Act);
@@ -404,43 +410,44 @@ int ExecuteTemplightInvocation(CompilerInstance *Clang) {
   return !Success;
 }
 
+static void ExecuteTemplightCommand(
+    Driver &TheDriver, DiagnosticsEngine &Diags, Compilation &C, Command &J,
+    const char *Argv0,
+    SmallVector<std::pair<int, const Command *>, 4> &FailingCommands) {
 
-
-static
-void ExecuteTemplightCommand(Driver &TheDriver, DiagnosticsEngine &Diags,
-    Compilation &C, Command &J, const char* Argv0,
-    SmallVector<std::pair<int, const Command *>, 4>& FailingCommands) {
-
-  // Since commandLineFitsWithinSystemLimits() may underestimate system's capacity
-  // if the tool does not support response files, there is a chance/ that things
-  // will just work without a response file, so we silently just skip it.
-  if ( J.getCreator().getResponseFilesSupport() != Tool::RF_None &&
-       llvm::sys::commandLineFitsWithinSystemLimits(J.getExecutable(), J.getArguments()) ) {
+  // Since commandLineFitsWithinSystemLimits() may underestimate system's
+  // capacity if the tool does not support response files, there is a chance/
+  // that things will just work without a response file, so we silently just
+  // skip it.
+  if (J.getCreator().getResponseFilesSupport() != Tool::RF_None &&
+      llvm::sys::commandLineFitsWithinSystemLimits(J.getExecutable(),
+                                                   J.getArguments())) {
     std::string TmpName = TheDriver.GetTemporaryPath("response", "txt");
-    J.setResponseFile(C.addTempFile(C.getArgs().MakeArgString(TmpName.c_str())));
+    J.setResponseFile(
+        C.addTempFile(C.getArgs().MakeArgString(TmpName.c_str())));
   }
 
-  if ( StringRef(J.getCreator().getName()) == "clang" ) {
+  if (StringRef(J.getCreator().getName()) == "clang") {
     // Initialize a compiler invocation object from the clang (-cc1) arguments.
     const ArgStringList &cc_arguments = J.getArguments();
-    const char** args_start = const_cast<const char**>(cc_arguments.data());
-    const char** args_end = args_start + cc_arguments.size();
+    const char **args_start = const_cast<const char **>(cc_arguments.data());
+    const char **args_end = args_start + cc_arguments.size();
 
     std::unique_ptr<CompilerInstance> Clang(new CompilerInstance());
 
-    int Res = !CompilerInvocation::CreateFromArgs(
-        Clang->getInvocation(), args_start, args_end, Diags);
-    if(Res)
+    int Res = !CompilerInvocation::CreateFromArgs(Clang->getInvocation(),
+                                                  args_start, args_end, Diags);
+    if (Res)
       FailingCommands.push_back(std::make_pair(Res, &J));
 
     Clang->getFrontendOpts().DisableFree = false;
 
     // Infer the builtin include path if unspecified.
-    void *GetExecutablePathVP = (void *)(intptr_t) GetExecutablePath;
+    void *GetExecutablePathVP = (void *)(intptr_t)GetExecutablePath;
     if (Clang->getHeaderSearchOpts().UseBuiltinIncludes &&
         Clang->getHeaderSearchOpts().ResourceDir.empty())
       Clang->getHeaderSearchOpts().ResourceDir =
-        CompilerInvocation::GetResourcesPath(Argv0, GetExecutablePathVP);
+          CompilerInvocation::GetResourcesPath(Argv0, GetExecutablePathVP);
 
     // Create the compilers actual diagnostics engine.
     Clang->createDiagnostics();
@@ -449,20 +456,22 @@ void ExecuteTemplightCommand(Driver &TheDriver, DiagnosticsEngine &Diags,
       return;
     }
 
-    LocalOutputFilename = ""; // Let the filename be created from options or output file name.
+    LocalOutputFilename =
+        ""; // Let the filename be created from options or output file name.
     std::string TemplightOutFile = TemplightAction::CreateOutputFilename(
-      Clang.get(), "", InstProfiler, OutputToStdOut, MemoryProfile);
+        Clang.get(), "", InstProfiler, OutputToStdOut, MemoryProfile);
     // Check if templight filename is in a temporary path:
     llvm::SmallString<128> TDir;
     llvm::sys::path::system_temp_directory(true, TDir);
-    if ( TDir.equals(llvm::sys::path::parent_path(llvm::StringRef(TemplightOutFile))) ) {
+    if (TDir.equals(
+            llvm::sys::path::parent_path(llvm::StringRef(TemplightOutFile)))) {
       C.addTempFile(TemplightOutFile.c_str());
       TempOutputFiles.push_back(TemplightOutFile);
     }
 
     // Execute the frontend actions.
     Res = ExecuteTemplightInvocation(Clang.get());
-    if(Res)
+    if (Res)
       FailingCommands.push_back(std::make_pair(Res, &J));
 
   } else {
@@ -470,12 +479,8 @@ void ExecuteTemplightCommand(Driver &TheDriver, DiagnosticsEngine &Diags,
     const Command *FailingCommand = nullptr;
     if (int Res = C.ExecuteCommand(J, FailingCommand))
       FailingCommands.push_back(std::make_pair(Res, FailingCommand));
-
   }
-
 }
-
-
 
 int main(int argc_, const char **argv_) {
   llvm::sys::PrintStackTraceOnErrorSignal(argv_[0]);
@@ -514,26 +519,28 @@ int main(int argc_, const char **argv_) {
     MarkEOLs = false;
   llvm::cl::ExpandResponseFiles(Saver, Tokenizer, argv, MarkEOLs);
 
-  // Separate out templight and clang flags.  templight flags are "-Xtemplight <templight_flag>"
+  // Separate out templight and clang flags.  templight flags are "-Xtemplight
+  // <templight_flag>"
   SmallVector<const char *, 256> templight_argv, clang_argv;
   templight_argv.push_back(argv[0]);
   clang_argv.push_back(argv[0]);
-  for (int i = 1, size = argv.size(); i < size; /* in loop */ ) {
-    if ((argv[i] != nullptr) &&
-        (strcmp(argv[i], "-Xtemplight") == 0)) {
-      while( i < size - 1 && argv[++i] == nullptr ) /* skip EOLs */ ;
-      templight_argv.push_back(argv[i]);   // the word after -Xtemplight
-      if( i == size - 1 ) // was this the last argument?
+  for (int i = 1, size = argv.size(); i < size; /* in loop */) {
+    if ((argv[i] != nullptr) && (strcmp(argv[i], "-Xtemplight") == 0)) {
+      while (i < size - 1 && argv[++i] == nullptr) /* skip EOLs */
+        ;
+      templight_argv.push_back(argv[i]); // the word after -Xtemplight
+      if (i == size - 1)                 // was this the last argument?
         break;
-      while( i < size - 1 && argv[++i] == nullptr ) /* skip EOLs */ ;
+      while (i < size - 1 && argv[++i] == nullptr) /* skip EOLs */
+        ;
     } else {
-      if ((argv[i] != nullptr) &&
-          ((strcmp(argv[i], "-help") == 0) ||
-           (strcmp(argv[i], "--help") == 0))) {
+      if ((argv[i] != nullptr) && ((strcmp(argv[i], "-help") == 0) ||
+                                   (strcmp(argv[i], "--help") == 0))) {
         // Print the help for the templight options:
         PrintTemplightHelp();
       }
-      clang_argv.push_back(argv[i++]);  // also leave -help to driver (to print its help info too)
+      clang_argv.push_back(
+          argv[i++]); // also leave -help to driver (to print its help info too)
     }
   }
 
@@ -557,8 +564,8 @@ int main(int argc_, const char **argv_) {
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts =
       CreateAndPopulateDiagOpts(clang_argv);
 
-  TextDiagnosticPrinter *DiagClient
-    = new TextDiagnosticPrinter(llvm::errs(), &*DiagOpts);
+  TextDiagnosticPrinter *DiagClient =
+      new TextDiagnosticPrinter(llvm::errs(), &*DiagOpts);
   FixupDiagPrefixExeName(DiagClient, Path);
 
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID(new DiagnosticIDs());
@@ -578,7 +585,7 @@ int main(int argc_, const char **argv_) {
   // Prepare a variable for the return value:
   int Res = 0;
 
-  void *GetExecutablePathVP = (void *)(intptr_t) GetExecutablePath;
+  void *GetExecutablePathVP = (void *)(intptr_t)GetExecutablePath;
 
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -594,7 +601,8 @@ int main(int argc_, const char **argv_) {
   // file.
   auto FirstArg = std::find_if(clang_argv.begin() + 1, clang_argv.end(),
                                [](const char *A) { return A != nullptr; });
-  bool invokeCC1 = (FirstArg != clang_argv.end() && StringRef(*FirstArg).startswith("-cc1"));
+  bool invokeCC1 =
+      (FirstArg != clang_argv.end() && StringRef(*FirstArg).startswith("-cc1"));
   if (invokeCC1) {
     // If -cc1 came from a response file, remove the EOL sentinels.
     if (MarkEOLs) {
@@ -604,14 +612,16 @@ int main(int argc_, const char **argv_) {
 
     std::unique_ptr<CompilerInstance> Clang(new CompilerInstance());
 
-    Res = !CompilerInvocation::CreateFromArgs(
-        Clang->getInvocation(), clang_argv.begin() + 2, clang_argv.end(), Diags);
+    Res = !CompilerInvocation::CreateFromArgs(Clang->getInvocation(),
+                                              clang_argv.begin() + 2,
+                                              clang_argv.end(), Diags);
 
     // Infer the builtin include path if unspecified.
     if (Clang->getHeaderSearchOpts().UseBuiltinIncludes &&
         Clang->getHeaderSearchOpts().ResourceDir.empty())
       Clang->getHeaderSearchOpts().ResourceDir =
-        CompilerInvocation::GetResourcesPath(clang_argv[0], GetExecutablePathVP);
+          CompilerInvocation::GetResourcesPath(clang_argv[0],
+                                               GetExecutablePathVP);
 
     // Create the compilers actual diagnostics engine.
     Clang->createDiagnostics();
@@ -644,38 +654,42 @@ int main(int argc_, const char **argv_) {
     SetBackdoorDriverOutputsFromEnvVars(TheDriver);
 
     std::unique_ptr<Compilation> C(TheDriver.BuildCompilation(clang_argv));
-    if(!C.get()) {
+    if (!C.get()) {
       Res = 1;
       goto cleanup;
     }
 
     SmallVector<std::pair<int, const Command *>, 4> FailingCommands;
     for (auto &J : C->getJobs())
-      ExecuteTemplightCommand(TheDriver, Diags, *C, J, clang_argv[0], FailingCommands);
+      ExecuteTemplightCommand(TheDriver, Diags, *C, J, clang_argv[0],
+                              FailingCommands);
 
     // Merge all the temp files into a single output file:
-    if ( ! TempOutputFiles.empty() ) {
-      if ( OutputFilename.empty() )
+    if (!TempOutputFiles.empty()) {
+      if (OutputFilename.empty())
         OutputFilename = "a";
       std::string FinalOutputFilename = TemplightAction::CreateOutputFilename(
-        nullptr, OutputFilename,
-        InstProfiler, OutputToStdOut, MemoryProfile);
-      if ( ( !FinalOutputFilename.empty() ) && ( FinalOutputFilename != "-" ) ) {
+          nullptr, OutputFilename, InstProfiler, OutputToStdOut, MemoryProfile);
+      if ((!FinalOutputFilename.empty()) && (FinalOutputFilename != "-")) {
         std::error_code error;
-        llvm::raw_fd_ostream TraceOS(FinalOutputFilename, error, llvm::sys::fs::F_None);
-        if ( error ) {
-          llvm::errs() <<
-            "Error: [Templight] Can not open file to write trace of template instantiations: "
-            << FinalOutputFilename << " Error: " << error.message();
+        llvm::raw_fd_ostream TraceOS(FinalOutputFilename, error,
+                                     llvm::sys::fs::F_None);
+        if (error) {
+          llvm::errs() << "Error: [Templight] Can not open file to write trace "
+                          "of template instantiations: "
+                       << FinalOutputFilename << " Error: " << error.message();
         } else {
-          for ( SmallVector< std::string, 32 >::iterator it = TempOutputFiles.begin(),
-                it_end = TempOutputFiles.end(); it != it_end; ++it) {
-            llvm::ErrorOr< std::unique_ptr<llvm::MemoryBuffer> >
-              file_epbuf = llvm::MemoryBuffer::getFile(llvm::Twine(*it));
-            if(file_epbuf && file_epbuf.get()) {
+          for (SmallVector<std::string, 32>::iterator
+                   it = TempOutputFiles.begin(),
+                   it_end = TempOutputFiles.end();
+               it != it_end; ++it) {
+            llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> file_epbuf =
+                llvm::MemoryBuffer::getFile(llvm::Twine(*it));
+            if (file_epbuf && file_epbuf.get()) {
               TraceOS << StringRef(file_epbuf.get()->getBufferStart(),
-                file_epbuf.get()->getBufferEnd() - file_epbuf.get()->getBufferStart())
-                << '\n';
+                                   file_epbuf.get()->getBufferEnd() -
+                                       file_epbuf.get()->getBufferStart())
+                      << '\n';
             }
           }
         }
@@ -690,8 +704,10 @@ int main(int argc_, const char **argv_) {
 
     // Otherwise, remove result files and print extra information about abnormal
     // failures.
-    for (SmallVectorImpl< std::pair<int, const Command *> >::iterator it =
-          FailingCommands.begin(), ie = FailingCommands.end(); it != ie; ++it) {
+    for (SmallVectorImpl<std::pair<int, const Command *>>::iterator
+             it = FailingCommands.begin(),
+             ie = FailingCommands.end();
+         it != ie; ++it) {
       int FailRes = it->first;
       const Command *FailingCommand = it->second;
 
@@ -711,13 +727,12 @@ int main(int argc_, const char **argv_) {
       if (!FailingCommand->getCreator().hasGoodDiagnostics() || FailRes != 1) {
         if (FailRes < 0)
           Diags.Report(clang::diag::err_drv_command_signalled)
-            << FailingTool.getShortName();
+              << FailingTool.getShortName();
         else
           Diags.Report(clang::diag::err_drv_command_failed)
-            << FailingTool.getShortName() << FailRes;
+              << FailingTool.getShortName() << FailRes;
       }
     }
-
   }
 
 cleanup:

--- a/utils/ExtraWriters/TemplightExtraWriters.cpp
+++ b/utils/ExtraWriters/TemplightExtraWriters.cpp
@@ -1,4 +1,4 @@
-//===- TemplightExtraWriters.cpp ------ Clang Templight Extra Writers -*- C++ -*-===//
+//===- TemplightExtraWriters.cpp ----------------*- C++ -*-----------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -12,34 +12,32 @@
 #include <clang/Sema/ActiveTemplateInst.h>
 
 #include <llvm/Support/Format.h>
-#include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/YAMLTraits.h>
+#include <llvm/Support/raw_ostream.h>
 
 namespace clang {
 
+static const char *const SynthesisKindStrings[] = {
+    "TemplateInstantiation",
+    "DefaultTemplateArgumentInstantiation",
+    "DefaultFunctionArgumentInstantiation",
+    "ExplicitTemplateArgumentSubstitution",
+    "DeducedTemplateArgumentSubstitution",
+    "PriorTemplateArgumentSubstitution",
+    "DefaultTemplateArgumentChecking",
+    "ExceptionSpecInstantiation",
+    "DeclaringSpecialMember",
+    "DefiningSynthesizedFunction",
+    "Memoization"};
 
-static const char* const SynthesisKindStrings[] = {
-  "TemplateInstantiation",
-  "DefaultTemplateArgumentInstantiation",
-  "DefaultFunctionArgumentInstantiation",
-  "ExplicitTemplateArgumentSubstitution",
-  "DeducedTemplateArgumentSubstitution",
-  "PriorTemplateArgumentSubstitution",
-  "DefaultTemplateArgumentChecking",
-  "ExceptionSpecInstantiation",
-  "DeclaringSpecialMember",
-  "DefiningSynthesizedFunction",
-  "Memoization" };
-
-
-static std::string escapeXml(const std::string& Input) {
+static std::string escapeXml(const std::string &Input) {
   std::string Result;
   Result.reserve(64);
 
   unsigned i, pos = 0;
   for (i = 0; i < Input.length(); ++i) {
-    if (Input[i] == '<' || Input[i] == '>' || Input[i] == '"'
-      || Input[i] == '\'' || Input[i] == '&') {
+    if (Input[i] == '<' || Input[i] == '>' || Input[i] == '"' ||
+        Input[i] == '\'' || Input[i] == '&') {
       Result.insert(Result.length(), Input, pos, i - pos);
       pos = i + 1;
       switch (Input[i]) {
@@ -67,18 +65,17 @@ static std::string escapeXml(const std::string& Input) {
   return Result;
 }
 
-
-
-} /* clang */ namespace llvm { namespace yaml {
+} // namespace clang
+namespace llvm {
+namespace yaml {
 
 template <>
 struct ScalarEnumerationTraits<
     clang::Sema::CodeSynthesisContext::SynthesisKind> {
-  static void enumeration(IO &io,
-    clang::Sema::CodeSynthesisContext::SynthesisKind &value) {
+  static void
+  enumeration(IO &io, clang::Sema::CodeSynthesisContext::SynthesisKind &value) {
 
-#define def_enum_case(e) \
-  io.enumCase(value, SynthesisKindStrings[e], e)
+#define def_enum_case(e) io.enumCase(value, SynthesisKindStrings[e], e)
 
     using namespace clang;
     def_enum_case(CodeSynthesisContext::TemplateInstantiation);
@@ -97,8 +94,7 @@ struct ScalarEnumerationTraits<
   }
 };
 
-template <>
-struct MappingTraits<clang::PrintableTemplightEntryBegin> {
+template <> struct MappingTraits<clang::PrintableTemplightEntryBegin> {
   static void mapping(IO &io, clang::PrintableTemplightEntryBegin &Entry) {
     bool b = true;
     io.mapRequired("IsBegin", b);
@@ -106,8 +102,7 @@ struct MappingTraits<clang::PrintableTemplightEntryBegin> {
     std::string kind = clang::SynthesisKindStrings[Entry.SynthesisKind];
     io.mapRequired("Kind", kind);
     io.mapOptional("Name", Entry.Name);
-    std::string loc = Entry.FileName + "|" +
-                      std::to_string(Entry.Line) + "|" +
+    std::string loc = Entry.FileName + "|" + std::to_string(Entry.Line) + "|" +
                       std::to_string(Entry.Column);
     io.mapOptional("Location", loc);
     io.mapRequired("TimeStamp", Entry.TimeStamp);
@@ -119,8 +114,7 @@ struct MappingTraits<clang::PrintableTemplightEntryBegin> {
   }
 };
 
-template <>
-struct MappingTraits<clang::PrintableTemplightEntryEnd> {
+template <> struct MappingTraits<clang::PrintableTemplightEntryEnd> {
   static void mapping(IO &io, clang::PrintableTemplightEntryEnd &Entry) {
     bool b = false;
     io.mapRequired("IsBegin", b);
@@ -129,134 +123,125 @@ struct MappingTraits<clang::PrintableTemplightEntryEnd> {
   }
 };
 
-} /* yaml */ } /* llvm */ namespace clang {
+} // namespace yaml
+} // namespace llvm
+namespace clang {
 
-
-void TemplightYamlWriter::initialize(const std::string& aSourceName) {
+void TemplightYamlWriter::initialize(const std::string &aSourceName) {
   Output->beginSequence();
 }
 
-void TemplightYamlWriter::finalize() {
-  Output->endSequence();
-}
+void TemplightYamlWriter::finalize() { Output->endSequence(); }
 
-void TemplightYamlWriter::printEntry(const PrintableTemplightEntryBegin& Entry) {
+void TemplightYamlWriter::printEntry(
+    const PrintableTemplightEntryBegin &Entry) {
   void *SaveInfo;
-  if ( Output->preflightElement(1, SaveInfo) ) {
+  if (Output->preflightElement(1, SaveInfo)) {
     llvm::yaml::EmptyContext Context;
-    llvm::yaml::yamlize(*Output, const_cast<PrintableTemplightEntryBegin&>(Entry),
-                        true, Context);
+    llvm::yaml::yamlize(*Output,
+                        const_cast<PrintableTemplightEntryBegin &>(Entry), true,
+                        Context);
     Output->postflightElement(SaveInfo);
   }
 }
 
-void TemplightYamlWriter::printEntry(const PrintableTemplightEntryEnd& Entry) {
+void TemplightYamlWriter::printEntry(const PrintableTemplightEntryEnd &Entry) {
   void *SaveInfo;
-  if ( Output->preflightElement(1, SaveInfo) ) {
+  if (Output->preflightElement(1, SaveInfo)) {
     llvm::yaml::EmptyContext Context;
-    llvm::yaml::yamlize(*Output, const_cast<PrintableTemplightEntryEnd&>(Entry),
-                        true, Context);
+    llvm::yaml::yamlize(*Output,
+                        const_cast<PrintableTemplightEntryEnd &>(Entry), true,
+                        Context);
     Output->postflightElement(SaveInfo);
   }
 }
 
-TemplightYamlWriter::TemplightYamlWriter(llvm::raw_ostream& aOS) : TemplightWriter(aOS) {
+TemplightYamlWriter::TemplightYamlWriter(llvm::raw_ostream &aOS)
+    : TemplightWriter(aOS) {
   Output.reset(new llvm::yaml::Output(OutputOS));
   Output->beginDocuments();
 }
 
-TemplightYamlWriter::~TemplightYamlWriter() {
-  Output->endDocuments();
-}
+TemplightYamlWriter::~TemplightYamlWriter() { Output->endDocuments(); }
 
-
-
-
-TemplightXmlWriter::TemplightXmlWriter(llvm::raw_ostream& aOS) : TemplightWriter(aOS) {
+TemplightXmlWriter::TemplightXmlWriter(llvm::raw_ostream &aOS)
+    : TemplightWriter(aOS) {
   OutputOS << "<?xml version=\"1.0\" standalone=\"yes\"?>\n";
 }
 
-TemplightXmlWriter::~TemplightXmlWriter() {
+TemplightXmlWriter::~TemplightXmlWriter() {}
 
-}
-
-void TemplightXmlWriter::initialize(const std::string& aSourceName) {
+void TemplightXmlWriter::initialize(const std::string &aSourceName) {
   OutputOS << "<Trace>\n";
 }
 
-void TemplightXmlWriter::finalize() {
-  OutputOS << "</Trace>\n";
-}
+void TemplightXmlWriter::finalize() { OutputOS << "</Trace>\n"; }
 
-void TemplightXmlWriter::printEntry(const PrintableTemplightEntryBegin& aEntry) {
+void TemplightXmlWriter::printEntry(
+    const PrintableTemplightEntryBegin &aEntry) {
   std::string EscapedName = escapeXml(aEntry.Name);
-  OutputOS << llvm::format(
-    "<TemplateBegin>\n"
-    "    <Kind>%s</Kind>\n"
-    "    <Context context = \"%s\"/>\n"
-    "    <Location>%s|%d|%d</Location>\n",
-    SynthesisKindStrings[aEntry.SynthesisKind], EscapedName.c_str(),
-    aEntry.FileName.c_str(), aEntry.Line, aEntry.Column);
-  OutputOS << llvm::format(
-    "    <TimeStamp time = \"%.9f\"/>\n"
-    "    <MemoryUsage bytes = \"%d\"/>\n",
-    aEntry.TimeStamp, aEntry.MemoryUsage);
-  if( !aEntry.TempOri_FileName.empty() ) {
-    OutputOS << llvm::format(
-      "    <TemplateOrigin>%s|%d|%d</TemplateOrigin>\n",
-      aEntry.TempOri_FileName.c_str(), aEntry.TempOri_Line, aEntry.TempOri_Column);
+  OutputOS << llvm::format("<TemplateBegin>\n"
+                           "    <Kind>%s</Kind>\n"
+                           "    <Context context = \"%s\"/>\n"
+                           "    <Location>%s|%d|%d</Location>\n",
+                           SynthesisKindStrings[aEntry.SynthesisKind],
+                           EscapedName.c_str(), aEntry.FileName.c_str(),
+                           aEntry.Line, aEntry.Column);
+  OutputOS << llvm::format("    <TimeStamp time = \"%.9f\"/>\n"
+                           "    <MemoryUsage bytes = \"%d\"/>\n",
+                           aEntry.TimeStamp, aEntry.MemoryUsage);
+  if (!aEntry.TempOri_FileName.empty()) {
+    OutputOS << llvm::format("    <TemplateOrigin>%s|%d|%d</TemplateOrigin>\n",
+                             aEntry.TempOri_FileName.c_str(),
+                             aEntry.TempOri_Line, aEntry.TempOri_Column);
   }
   OutputOS << "</TemplateBegin>\n";
 }
 
-void TemplightXmlWriter::printEntry(const PrintableTemplightEntryEnd& aEntry) {
-  OutputOS << llvm::format(
-    "<TemplateEnd>\n"
-    "    <TimeStamp time = \"%.9f\"/>\n"
-    "    <MemoryUsage bytes = \"%d\"/>\n"
-    "</TemplateEnd>\n",
-    aEntry.TimeStamp, aEntry.MemoryUsage);
+void TemplightXmlWriter::printEntry(const PrintableTemplightEntryEnd &aEntry) {
+  OutputOS << llvm::format("<TemplateEnd>\n"
+                           "    <TimeStamp time = \"%.9f\"/>\n"
+                           "    <MemoryUsage bytes = \"%d\"/>\n"
+                           "</TemplateEnd>\n",
+                           aEntry.TimeStamp, aEntry.MemoryUsage);
 }
 
-
-
-TemplightTextWriter::TemplightTextWriter(llvm::raw_ostream& aOS) : TemplightWriter(aOS) {}
+TemplightTextWriter::TemplightTextWriter(llvm::raw_ostream &aOS)
+    : TemplightWriter(aOS) {}
 
 TemplightTextWriter::~TemplightTextWriter() {}
 
-void TemplightTextWriter::initialize(const std::string& aSourceName) {
+void TemplightTextWriter::initialize(const std::string &aSourceName) {
   OutputOS << "  SourceFile = " << aSourceName << "\n";
 }
 
 void TemplightTextWriter::finalize() {}
 
-void TemplightTextWriter::printEntry(const PrintableTemplightEntryBegin& aEntry) {
-  OutputOS << llvm::format(
-    "TemplateBegin\n"
-    "  Kind = %s\n"
-    "  Name = %s\n"
-    "  Location = %s|%d|%d\n",
-    SynthesisKindStrings[aEntry.SynthesisKind], aEntry.Name.c_str(),
-    aEntry.FileName.c_str(), aEntry.Line, aEntry.Column);
-  OutputOS << llvm::format(
-    "  TimeStamp = %.9f\n"
-    "  MemoryUsage = %d\n",
-    aEntry.TimeStamp, aEntry.MemoryUsage);
-  if( !aEntry.TempOri_FileName.empty() ) {
-    OutputOS << llvm::format(
-      "  TemplateOrigin = %s|%d|%d\n",
-      aEntry.TempOri_FileName.c_str(), aEntry.TempOri_Line, aEntry.TempOri_Column);
+void TemplightTextWriter::printEntry(
+    const PrintableTemplightEntryBegin &aEntry) {
+  OutputOS << llvm::format("TemplateBegin\n"
+                           "  Kind = %s\n"
+                           "  Name = %s\n"
+                           "  Location = %s|%d|%d\n",
+                           SynthesisKindStrings[aEntry.SynthesisKind],
+                           aEntry.Name.c_str(), aEntry.FileName.c_str(),
+                           aEntry.Line, aEntry.Column);
+  OutputOS << llvm::format("  TimeStamp = %.9f\n"
+                           "  MemoryUsage = %d\n",
+                           aEntry.TimeStamp, aEntry.MemoryUsage);
+  if (!aEntry.TempOri_FileName.empty()) {
+    OutputOS << llvm::format("  TemplateOrigin = %s|%d|%d\n",
+                             aEntry.TempOri_FileName.c_str(),
+                             aEntry.TempOri_Line, aEntry.TempOri_Column);
   }
 }
 
-void TemplightTextWriter::printEntry(const PrintableTemplightEntryEnd& aEntry) {
-  OutputOS << llvm::format(
-    "TemplateEnd\n"
-    "  TimeStamp = %.9f\n"
-    "  MemoryUsage = %d\n",
-    aEntry.TimeStamp, aEntry.MemoryUsage);
+void TemplightTextWriter::printEntry(const PrintableTemplightEntryEnd &aEntry) {
+  OutputOS << llvm::format("TemplateEnd\n"
+                           "  TimeStamp = %.9f\n"
+                           "  MemoryUsage = %d\n",
+                           aEntry.TimeStamp, aEntry.MemoryUsage);
 }
-
 
 struct EntryTraversalTask {
   static const std::size_t invalid_id = ~std::size_t(0);
@@ -264,11 +249,10 @@ struct EntryTraversalTask {
   PrintableTemplightEntryBegin start;
   PrintableTemplightEntryEnd finish;
   std::size_t nd_id, id_end, parent_id;
-  EntryTraversalTask(const PrintableTemplightEntryBegin& aStart,
-                     std::size_t aNdId, std::size_t aParentId) :
-                     start(aStart), finish(),
-                     nd_id(aNdId), id_end(invalid_id),
-                     parent_id(aParentId) { };
+  EntryTraversalTask(const PrintableTemplightEntryBegin &aStart,
+                     std::size_t aNdId, std::size_t aParentId)
+      : start(aStart), finish(), nd_id(aNdId), id_end(invalid_id),
+        parent_id(aParentId){};
 };
 
 struct RecordedDFSEntryTree {
@@ -277,231 +261,214 @@ struct RecordedDFSEntryTree {
   std::vector<EntryTraversalTask> parent_stack;
   std::size_t cur_top;
 
-  RecordedDFSEntryTree() : cur_top(invalid_id) { };
+  RecordedDFSEntryTree() : cur_top(invalid_id){};
 
-  void beginEntry(const PrintableTemplightEntryBegin& aEntry) {
-    parent_stack.push_back(EntryTraversalTask(
-      aEntry, parent_stack.size(), ( cur_top == invalid_id ? invalid_id : cur_top)));
+  void beginEntry(const PrintableTemplightEntryBegin &aEntry) {
+    parent_stack.push_back(
+        EntryTraversalTask(aEntry, parent_stack.size(),
+                           (cur_top == invalid_id ? invalid_id : cur_top)));
     cur_top = parent_stack.size() - 1;
   };
 
-  void endEntry(const PrintableTemplightEntryEnd& aEntry) {
+  void endEntry(const PrintableTemplightEntryEnd &aEntry) {
     parent_stack[cur_top].finish = aEntry;
     parent_stack[cur_top].id_end = parent_stack.size();
-    if ( parent_stack[cur_top].parent_id == invalid_id )
+    if (parent_stack[cur_top].parent_id == invalid_id)
       cur_top = invalid_id;
     else
       cur_top = parent_stack[cur_top].parent_id;
   };
-
 };
 
+TemplightTreeWriter::TemplightTreeWriter(llvm::raw_ostream &aOS)
+    : TemplightWriter(aOS), p_tree(new RecordedDFSEntryTree()) {}
 
+TemplightTreeWriter::~TemplightTreeWriter() {}
 
-TemplightTreeWriter::TemplightTreeWriter(llvm::raw_ostream& aOS) :
-  TemplightWriter(aOS), p_tree(new RecordedDFSEntryTree()) { }
-
-TemplightTreeWriter::~TemplightTreeWriter() { }
-
-void TemplightTreeWriter::printEntry(const PrintableTemplightEntryBegin& aEntry) {
+void TemplightTreeWriter::printEntry(
+    const PrintableTemplightEntryBegin &aEntry) {
   p_tree->beginEntry(aEntry);
 }
 
-void TemplightTreeWriter::printEntry(const PrintableTemplightEntryEnd& aEntry) {
+void TemplightTreeWriter::printEntry(const PrintableTemplightEntryEnd &aEntry) {
   p_tree->endEntry(aEntry);
 }
 
-void TemplightTreeWriter::initialize(const std::string& aSourceName) {
+void TemplightTreeWriter::initialize(const std::string &aSourceName) {
   this->initializeTree(aSourceName);
 }
 
 void TemplightTreeWriter::finalize() {
   std::vector<std::size_t> open_set;
-  std::vector<EntryTraversalTask>& tree = p_tree->parent_stack;
+  std::vector<EntryTraversalTask> &tree = p_tree->parent_stack;
 
-  for(std::size_t i = 0, i_end = tree.size(); i != i_end; ++i ) {
-    while ( !open_set.empty() && (i >= tree[open_set.back()].id_end) ) {
+  for (std::size_t i = 0, i_end = tree.size(); i != i_end; ++i) {
+    while (!open_set.empty() && (i >= tree[open_set.back()].id_end)) {
       closePrintedTreeNode(tree[open_set.back()]);
       open_set.pop_back();
     }
     openPrintedTreeNode(tree[i]);
     open_set.push_back(i);
   }
-  while ( !open_set.empty() ) {
+  while (!open_set.empty()) {
     closePrintedTreeNode(tree[open_set.back()]);
     open_set.pop_back();
   }
 
   this->finalizeTree();
-
 }
 
-
-
-TemplightNestedXMLWriter::TemplightNestedXMLWriter(llvm::raw_ostream& aOS) :
-  TemplightTreeWriter(aOS) {
+TemplightNestedXMLWriter::TemplightNestedXMLWriter(llvm::raw_ostream &aOS)
+    : TemplightTreeWriter(aOS) {
   OutputOS << "<?xml version=\"1.0\" standalone=\"yes\"?>\n";
 }
 
-TemplightNestedXMLWriter::~TemplightNestedXMLWriter() { }
+TemplightNestedXMLWriter::~TemplightNestedXMLWriter() {}
 
-void TemplightNestedXMLWriter::initializeTree(const std::string& aSourceName) {
+void TemplightNestedXMLWriter::initializeTree(const std::string &aSourceName) {
   OutputOS << "<Trace>\n";
 }
 
-void TemplightNestedXMLWriter::finalizeTree() {
-  OutputOS << "</Trace>\n";
-}
+void TemplightNestedXMLWriter::finalizeTree() { OutputOS << "</Trace>\n"; }
 
-void TemplightNestedXMLWriter::openPrintedTreeNode(const EntryTraversalTask& aNode) {
-  const PrintableTemplightEntryBegin& BegEntry = aNode.start;
-  const PrintableTemplightEntryEnd&   EndEntry = aNode.finish;
+void TemplightNestedXMLWriter::openPrintedTreeNode(
+    const EntryTraversalTask &aNode) {
+  const PrintableTemplightEntryBegin &BegEntry = aNode.start;
+  const PrintableTemplightEntryEnd &EndEntry = aNode.finish;
   std::string EscapedName = escapeXml(BegEntry.Name);
 
-  OutputOS << llvm::format(
-    "<Entry Kind=\"%s\" Name=\"%s\" ",
-    SynthesisKindStrings[BegEntry.SynthesisKind], EscapedName.c_str());
-  OutputOS << llvm::format(
-    "Location=\"%s|%d|%d\" ",
-    BegEntry.FileName.c_str(), BegEntry.Line, BegEntry.Column);
-  if( !BegEntry.TempOri_FileName.empty() ) {
-    OutputOS << llvm::format(
-      "TemplateOrigin=\"%s|%d|%d\" ",
-      BegEntry.TempOri_FileName.c_str(), BegEntry.TempOri_Line, BegEntry.TempOri_Column);
+  OutputOS << llvm::format("<Entry Kind=\"%s\" Name=\"%s\" ",
+                           SynthesisKindStrings[BegEntry.SynthesisKind],
+                           EscapedName.c_str());
+  OutputOS << llvm::format("Location=\"%s|%d|%d\" ", BegEntry.FileName.c_str(),
+                           BegEntry.Line, BegEntry.Column);
+  if (!BegEntry.TempOri_FileName.empty()) {
+    OutputOS << llvm::format("TemplateOrigin=\"%s|%d|%d\" ",
+                             BegEntry.TempOri_FileName.c_str(),
+                             BegEntry.TempOri_Line, BegEntry.TempOri_Column);
   }
-  OutputOS << llvm::format(
-    "Time=\"%.9f\" Memory=\"%d\">\n",
-    EndEntry.TimeStamp - BegEntry.TimeStamp,
-    EndEntry.MemoryUsage - BegEntry.MemoryUsage);
+  OutputOS << llvm::format("Time=\"%.9f\" Memory=\"%d\">\n",
+                           EndEntry.TimeStamp - BegEntry.TimeStamp,
+                           EndEntry.MemoryUsage - BegEntry.MemoryUsage);
 
   // Print only first part (heading).
 }
 
-void TemplightNestedXMLWriter::closePrintedTreeNode(const EntryTraversalTask& aNode) {
+void TemplightNestedXMLWriter::closePrintedTreeNode(
+    const EntryTraversalTask &aNode) {
   OutputOS << "</Entry>\n";
 }
 
-
-
-
-TemplightGraphMLWriter::TemplightGraphMLWriter(llvm::raw_ostream& aOS) :
-  TemplightTreeWriter(aOS), last_edge_id(0) {
-  OutputOS <<
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-    "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\""
-    " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
-    " xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns"
-    " http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
-  OutputOS <<
-    "<key id=\"d0\" for=\"node\" attr.name=\"Kind\" attr.type=\"string\"/>\n"
-    "<key id=\"d1\" for=\"node\" attr.name=\"Name\" attr.type=\"string\"/>\n"
-    "<key id=\"d2\" for=\"node\" attr.name=\"Location\" attr.type=\"string\"/>\n"
-    "<key id=\"d3\" for=\"node\" attr.name=\"Time\" attr.type=\"double\">\n"
-      "<default>0.0</default>\n"
-    "</key>\n"
-    "<key id=\"d4\" for=\"node\" attr.name=\"Memory\" attr.type=\"long\">\n"
-      "<default>0</default>\n"
-    "</key>\n"
-    "<key id=\"d5\" for=\"node\" attr.name=\"TemplateOrigin\" attr.type=\"string\"/>\n";
+TemplightGraphMLWriter::TemplightGraphMLWriter(llvm::raw_ostream &aOS)
+    : TemplightTreeWriter(aOS), last_edge_id(0) {
+  OutputOS << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+              "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\""
+              " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+              " xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns"
+              " http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n";
+  OutputOS << "<key id=\"d0\" for=\"node\" attr.name=\"Kind\" "
+              "attr.type=\"string\"/>\n"
+              "<key id=\"d1\" for=\"node\" attr.name=\"Name\" "
+              "attr.type=\"string\"/>\n"
+              "<key id=\"d2\" for=\"node\" attr.name=\"Location\" "
+              "attr.type=\"string\"/>\n"
+              "<key id=\"d3\" for=\"node\" attr.name=\"Time\" "
+              "attr.type=\"double\">\n"
+              "<default>0.0</default>\n"
+              "</key>\n"
+              "<key id=\"d4\" for=\"node\" attr.name=\"Memory\" "
+              "attr.type=\"long\">\n"
+              "<default>0</default>\n"
+              "</key>\n"
+              "<key id=\"d5\" for=\"node\" attr.name=\"TemplateOrigin\" "
+              "attr.type=\"string\"/>\n";
 }
 
 TemplightGraphMLWriter::~TemplightGraphMLWriter() {
   OutputOS << "</graphml>\n";
 }
 
-void TemplightGraphMLWriter::initializeTree(const std::string& aSourceName) {
+void TemplightGraphMLWriter::initializeTree(const std::string &aSourceName) {
   OutputOS << "<graph>\n";
 }
 
-void TemplightGraphMLWriter::finalizeTree() {
-  OutputOS << "</graph>\n";
-}
+void TemplightGraphMLWriter::finalizeTree() { OutputOS << "</graph>\n"; }
 
-void TemplightGraphMLWriter::openPrintedTreeNode(const EntryTraversalTask& aNode) {
-  const PrintableTemplightEntryBegin& BegEntry = aNode.start;
-  const PrintableTemplightEntryEnd&   EndEntry = aNode.finish;
+void TemplightGraphMLWriter::openPrintedTreeNode(
+    const EntryTraversalTask &aNode) {
+  const PrintableTemplightEntryBegin &BegEntry = aNode.start;
+  const PrintableTemplightEntryEnd &EndEntry = aNode.finish;
 
   OutputOS << llvm::format("<node id=\"n%d\">\n", aNode.nd_id);
 
   std::string EscapedName = escapeXml(BegEntry.Name);
-  OutputOS << llvm::format(
-    "  <data key=\"d0\">%s</data>\n"
-    "  <data key=\"d1\">\"%s\"</data>\n"
-    "  <data key=\"d2\">\"%s|%d|%d\"</data>\n",
-    SynthesisKindStrings[BegEntry.SynthesisKind], EscapedName.c_str(),
-    BegEntry.FileName.c_str(), BegEntry.Line, BegEntry.Column);
-  OutputOS << llvm::format(
-    "  <data key=\"d3\">%.9f</data>\n"
-    "  <data key=\"d4\">%d</data>\n",
-    EndEntry.TimeStamp - BegEntry.TimeStamp,
-    EndEntry.MemoryUsage - BegEntry.MemoryUsage);
-  if( !BegEntry.TempOri_FileName.empty() ) {
-    OutputOS << llvm::format(
-      "  <data key=\"d2\">\"%s|%d|%d\"</data>\n",
-      BegEntry.TempOri_FileName.c_str(), BegEntry.TempOri_Line, BegEntry.TempOri_Column);
+  OutputOS << llvm::format("  <data key=\"d0\">%s</data>\n"
+                           "  <data key=\"d1\">\"%s\"</data>\n"
+                           "  <data key=\"d2\">\"%s|%d|%d\"</data>\n",
+                           SynthesisKindStrings[BegEntry.SynthesisKind],
+                           EscapedName.c_str(), BegEntry.FileName.c_str(),
+                           BegEntry.Line, BegEntry.Column);
+  OutputOS << llvm::format("  <data key=\"d3\">%.9f</data>\n"
+                           "  <data key=\"d4\">%d</data>\n",
+                           EndEntry.TimeStamp - BegEntry.TimeStamp,
+                           EndEntry.MemoryUsage - BegEntry.MemoryUsage);
+  if (!BegEntry.TempOri_FileName.empty()) {
+    OutputOS << llvm::format("  <data key=\"d2\">\"%s|%d|%d\"</data>\n",
+                             BegEntry.TempOri_FileName.c_str(),
+                             BegEntry.TempOri_Line, BegEntry.TempOri_Column);
   }
 
   OutputOS << "</node>\n";
-  if ( aNode.parent_id == RecordedDFSEntryTree::invalid_id )
+  if (aNode.parent_id == RecordedDFSEntryTree::invalid_id)
     return;
 
-  OutputOS << llvm::format(
-    "<edge id=\"e%d\" source=\"n%d\" target=\"n%d\"/>\n",
-    last_edge_id++, aNode.parent_id, aNode.nd_id);
+  OutputOS << llvm::format("<edge id=\"e%d\" source=\"n%d\" target=\"n%d\"/>\n",
+                           last_edge_id++, aNode.parent_id, aNode.nd_id);
 }
 
-void TemplightGraphMLWriter::closePrintedTreeNode(const EntryTraversalTask& aNode) {}
+void TemplightGraphMLWriter::closePrintedTreeNode(
+    const EntryTraversalTask &aNode) {}
 
-
-
-
-TemplightGraphVizWriter::TemplightGraphVizWriter(llvm::raw_ostream& aOS) :
-  TemplightTreeWriter(aOS) { }
+TemplightGraphVizWriter::TemplightGraphVizWriter(llvm::raw_ostream &aOS)
+    : TemplightTreeWriter(aOS) {}
 
 TemplightGraphVizWriter::~TemplightGraphVizWriter() {}
 
-void TemplightGraphVizWriter::initializeTree(const std::string& aSourceName) {
+void TemplightGraphVizWriter::initializeTree(const std::string &aSourceName) {
   OutputOS << "digraph Trace {\n";
 }
 
-void TemplightGraphVizWriter::finalizeTree() {
-  OutputOS << "}\n";
-}
+void TemplightGraphVizWriter::finalizeTree() { OutputOS << "}\n"; }
 
-void TemplightGraphVizWriter::openPrintedTreeNode(const EntryTraversalTask& aNode) {
-  const PrintableTemplightEntryBegin& BegEntry = aNode.start;
-  const PrintableTemplightEntryEnd&   EndEntry = aNode.finish;
+void TemplightGraphVizWriter::openPrintedTreeNode(
+    const EntryTraversalTask &aNode) {
+  const PrintableTemplightEntryBegin &BegEntry = aNode.start;
+  const PrintableTemplightEntryEnd &EndEntry = aNode.finish;
 
   std::string EscapedName = escapeXml(BegEntry.Name);
-  OutputOS
-    << llvm::format("n%d [label = ", aNode.nd_id)
-    << llvm::format(
-        "\"%s\\n"
-        "%s\\n"
-        "At %s Line %d Column %d\\n",
-      SynthesisKindStrings[BegEntry.SynthesisKind], EscapedName.c_str(),
-      BegEntry.FileName.c_str(), BegEntry.Line, BegEntry.Column);
-  if( !BegEntry.TempOri_FileName.empty() ) {
-    OutputOS << llvm::format(
-      "From %s Line %d Column %d\\n",
-      BegEntry.TempOri_FileName.c_str(), BegEntry.TempOri_Line, BegEntry.TempOri_Column);
+  OutputOS << llvm::format("n%d [label = ", aNode.nd_id)
+           << llvm::format("\"%s\\n"
+                           "%s\\n"
+                           "At %s Line %d Column %d\\n",
+                           SynthesisKindStrings[BegEntry.SynthesisKind],
+                           EscapedName.c_str(), BegEntry.FileName.c_str(),
+                           BegEntry.Line, BegEntry.Column);
+  if (!BegEntry.TempOri_FileName.empty()) {
+    OutputOS << llvm::format("From %s Line %d Column %d\\n",
+                             BegEntry.TempOri_FileName.c_str(),
+                             BegEntry.TempOri_Line, BegEntry.TempOri_Column);
   }
-  OutputOS
-    << llvm::format(
-        "Time: %.9f seconds Memory: %d bytes\" ];\n",
-      EndEntry.TimeStamp - BegEntry.TimeStamp,
-      EndEntry.MemoryUsage - BegEntry.MemoryUsage);
+  OutputOS << llvm::format("Time: %.9f seconds Memory: %d bytes\" ];\n",
+                           EndEntry.TimeStamp - BegEntry.TimeStamp,
+                           EndEntry.MemoryUsage - BegEntry.MemoryUsage);
 
-  if ( aNode.parent_id == RecordedDFSEntryTree::invalid_id )
+  if (aNode.parent_id == RecordedDFSEntryTree::invalid_id)
     return;
 
-  OutputOS << llvm::format(
-    "n%d -> n%d;\n",
-    aNode.parent_id, aNode.nd_id);
+  OutputOS << llvm::format("n%d -> n%d;\n", aNode.parent_id, aNode.nd_id);
 }
 
-void TemplightGraphVizWriter::closePrintedTreeNode(const EntryTraversalTask& aNode) {}
+void TemplightGraphVizWriter::closePrintedTreeNode(
+    const EntryTraversalTask &aNode) {}
 
-
-}
-
+} // namespace clang

--- a/utils/ExtraWriters/TemplightExtraWriters.h
+++ b/utils/ExtraWriters/TemplightExtraWriters.h
@@ -1,4 +1,4 @@
-//===- TemplightProtobufWriter.h ------ Clang Templight Protobuf Writer -*- C++ -*-===//
+//===- TemplightProtobufWriter.h --------------------*- C++ -*-------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -18,139 +18,117 @@
 #include <string>
 
 namespace llvm {
-  namespace yaml {
-    class Output;
-  }
+namespace yaml {
+class Output;
 }
-
+} // namespace llvm
 
 namespace clang {
 
-
 class TemplightYamlWriter : public TemplightWriter {
 public:
-  
-  TemplightYamlWriter(llvm::raw_ostream& aOS);
+  TemplightYamlWriter(llvm::raw_ostream &aOS);
   ~TemplightYamlWriter();
-  
-  void initialize(const std::string& aSourceName = "") override;
+
+  void initialize(const std::string &aSourceName = "") override;
   void finalize() override;
-  
-  void printEntry(const PrintableTemplightEntryBegin& aEntry) override;
-  void printEntry(const PrintableTemplightEntryEnd& aEntry) override;
-  
+
+  void printEntry(const PrintableTemplightEntryBegin &aEntry) override;
+  void printEntry(const PrintableTemplightEntryEnd &aEntry) override;
+
 private:
   std::unique_ptr<llvm::yaml::Output> Output;
 };
 
-
 class TemplightXmlWriter : public TemplightWriter {
 public:
-  
-  TemplightXmlWriter(llvm::raw_ostream& aOS);
+  TemplightXmlWriter(llvm::raw_ostream &aOS);
   ~TemplightXmlWriter();
-  
-  void initialize(const std::string& aSourceName = "") override;
-  void finalize() override;
-  
-  void printEntry(const PrintableTemplightEntryBegin& aEntry) override;
-  void printEntry(const PrintableTemplightEntryEnd& aEntry) override;
-  
-};
 
+  void initialize(const std::string &aSourceName = "") override;
+  void finalize() override;
+
+  void printEntry(const PrintableTemplightEntryBegin &aEntry) override;
+  void printEntry(const PrintableTemplightEntryEnd &aEntry) override;
+};
 
 class TemplightTextWriter : public TemplightWriter {
 public:
-  
-  TemplightTextWriter(llvm::raw_ostream& aOS);
+  TemplightTextWriter(llvm::raw_ostream &aOS);
   ~TemplightTextWriter();
-  
-  void initialize(const std::string& aSourceName = "") override;
-  void finalize() override;
-  
-  void printEntry(const PrintableTemplightEntryBegin& aEntry) override;
-  void printEntry(const PrintableTemplightEntryEnd& aEntry) override;
-  
-};
 
+  void initialize(const std::string &aSourceName = "") override;
+  void finalize() override;
+
+  void printEntry(const PrintableTemplightEntryBegin &aEntry) override;
+  void printEntry(const PrintableTemplightEntryEnd &aEntry) override;
+};
 
 struct RecordedDFSEntryTree;
 struct EntryTraversalTask;
 
 class TemplightTreeWriter : public TemplightWriter {
 public:
-  
-  TemplightTreeWriter(llvm::raw_ostream& aOS);
+  TemplightTreeWriter(llvm::raw_ostream &aOS);
   ~TemplightTreeWriter();
-  
-  void initialize(const std::string& aSourceName = "") override;
+
+  void initialize(const std::string &aSourceName = "") override;
   void finalize() override;
-  
-  void printEntry(const PrintableTemplightEntryBegin& aEntry) override;
-  void printEntry(const PrintableTemplightEntryEnd& aEntry) override;
-  
+
+  void printEntry(const PrintableTemplightEntryBegin &aEntry) override;
+  void printEntry(const PrintableTemplightEntryEnd &aEntry) override;
+
 protected:
-  virtual void openPrintedTreeNode(const EntryTraversalTask& aNode) = 0;
-  virtual void closePrintedTreeNode(const EntryTraversalTask& aNode) = 0;
-  
-  virtual void initializeTree(const std::string& aSourceName) = 0;
+  virtual void openPrintedTreeNode(const EntryTraversalTask &aNode) = 0;
+  virtual void closePrintedTreeNode(const EntryTraversalTask &aNode) = 0;
+
+  virtual void initializeTree(const std::string &aSourceName) = 0;
   virtual void finalizeTree() = 0;
-  
+
   std::unique_ptr<RecordedDFSEntryTree> p_tree;
 };
 
-
-
 class TemplightNestedXMLWriter : public TemplightTreeWriter {
 public:
-  
-  TemplightNestedXMLWriter(llvm::raw_ostream& aOS);
+  TemplightNestedXMLWriter(llvm::raw_ostream &aOS);
   ~TemplightNestedXMLWriter();
-  
-protected:
-  void openPrintedTreeNode(const EntryTraversalTask& aNode) override;
-  void closePrintedTreeNode(const EntryTraversalTask& aNode) override;
-  
-  void initializeTree(const std::string& aSourceName = "") override;
-  void finalizeTree() override;
-  
-};
 
+protected:
+  void openPrintedTreeNode(const EntryTraversalTask &aNode) override;
+  void closePrintedTreeNode(const EntryTraversalTask &aNode) override;
+
+  void initializeTree(const std::string &aSourceName = "") override;
+  void finalizeTree() override;
+};
 
 class TemplightGraphMLWriter : public TemplightTreeWriter {
 public:
-  
-  TemplightGraphMLWriter(llvm::raw_ostream& aOS);
+  TemplightGraphMLWriter(llvm::raw_ostream &aOS);
   ~TemplightGraphMLWriter();
-  
+
 protected:
-  void openPrintedTreeNode(const EntryTraversalTask& aNode) override;
-  void closePrintedTreeNode(const EntryTraversalTask& aNode) override;
-  
-  void initializeTree(const std::string& aSourceName = "") override;
+  void openPrintedTreeNode(const EntryTraversalTask &aNode) override;
+  void closePrintedTreeNode(const EntryTraversalTask &aNode) override;
+
+  void initializeTree(const std::string &aSourceName = "") override;
   void finalizeTree() override;
-  
+
 private:
   int last_edge_id;
 };
 
-
 class TemplightGraphVizWriter : public TemplightTreeWriter {
 public:
-  
-  TemplightGraphVizWriter(llvm::raw_ostream& aOS);
+  TemplightGraphVizWriter(llvm::raw_ostream &aOS);
   ~TemplightGraphVizWriter();
-  
+
 protected:
-  void openPrintedTreeNode(const EntryTraversalTask& aNode) override;
-  void closePrintedTreeNode(const EntryTraversalTask& aNode) override;
-  
-  void initializeTree(const std::string& aSourceName = "") override;
+  void openPrintedTreeNode(const EntryTraversalTask &aNode) override;
+  void closePrintedTreeNode(const EntryTraversalTask &aNode) override;
+
+  void initializeTree(const std::string &aSourceName = "") override;
   void finalizeTree() override;
-  
 };
-
-
 
 /*
 class ProtobufPrinter : public TemplightTracer::TracePrinter {
@@ -166,7 +144,7 @@ protected:
     Writer.finalize();
     Writer.dumpOnStream(*this->TraceOS);
   };
-  
+
   void printEntryImpl(const PrintableTemplightEntryBegin& Entry) override {
     Writer.printEntry(Entry);
   };
@@ -174,19 +152,17 @@ protected:
   void printEntryImpl(const PrintableTemplightEntryEnd& Entry) override {
     Writer.printEntry(Entry);
   };
-  
+
 public:
-  
-  ProtobufPrinter(const Sema &aSema, const std::string &Output) : 
+
+  ProtobufPrinter(const Sema &aSema, const std::string &Output) :
                   TemplightTracer::TracePrinter(aSema, Output) { };
-  
+
 private:
   TemplightProtobufWriter Writer;
 };
 */
 
-}
+} // namespace clang
 
 #endif
-
-

--- a/utils/ProtobufReader/TemplightProtobufReader.cpp
+++ b/utils/ProtobufReader/TemplightProtobufReader.cpp
@@ -1,4 +1,4 @@
-//===- TemplightProtobufWriter.cpp ------ Clang Templight Protobuf Reader -*- C++ -*-===//
+//===- TemplightProtobufWriter.cpp -----------------*- C++ -*--------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -13,142 +13,141 @@
 
 #include <llvm/Support/Compression.h>
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace clang {
 
-
-TemplightProtobufReader::TemplightProtobufReader() { }
+TemplightProtobufReader::TemplightProtobufReader() {}
 
 void TemplightProtobufReader::loadHeader(llvm::StringRef aSubBuffer) {
   // Set default values:
   Version = 0;
   SourceName = "";
-  
-  while ( aSubBuffer.size() ) {
+
+  while (aSubBuffer.size()) {
     unsigned int cur_wire = llvm::protobuf::loadVarInt(aSubBuffer);
-    switch( cur_wire ) {
-      case llvm::protobuf::getVarIntWire<1>::value:
-        Version = llvm::protobuf::loadVarInt(aSubBuffer);
-        break;
-      case llvm::protobuf::getStringWire<2>::value:
-        SourceName = llvm::protobuf::loadString(aSubBuffer);
-        break;
-      default:
-        llvm::protobuf::skipData(aSubBuffer, cur_wire);
-        break;
+    switch (cur_wire) {
+    case llvm::protobuf::getVarIntWire<1>::value:
+      Version = llvm::protobuf::loadVarInt(aSubBuffer);
+      break;
+    case llvm::protobuf::getStringWire<2>::value:
+      SourceName = llvm::protobuf::loadString(aSubBuffer);
+      break;
+    default:
+      llvm::protobuf::skipData(aSubBuffer, cur_wire);
+      break;
     }
   }
-  
+
   LastChunk = TemplightProtobufReader::Header;
 }
 
 void TemplightProtobufReader::loadDictionaryEntry(llvm::StringRef aSubBuffer) {
   // Set default values:
   std::string name = "";
-  llvm::SmallVector<std::size_t,8> markers;
-  
-  while ( aSubBuffer.size() ) {
+  llvm::SmallVector<std::size_t, 8> markers;
+
+  while (aSubBuffer.size()) {
     unsigned int cur_wire = llvm::protobuf::loadVarInt(aSubBuffer);
-    switch( cur_wire ) {
-      case llvm::protobuf::getStringWire<1>::value:
-        name = llvm::protobuf::loadString(aSubBuffer);
-        break;
-      case llvm::protobuf::getVarIntWire<2>::value:
-        markers.push_back(llvm::protobuf::loadVarInt(aSubBuffer));
-        break;
-      default:
-        llvm::protobuf::skipData(aSubBuffer, cur_wire);
-        break;
+    switch (cur_wire) {
+    case llvm::protobuf::getStringWire<1>::value:
+      name = llvm::protobuf::loadString(aSubBuffer);
+      break;
+    case llvm::protobuf::getVarIntWire<2>::value:
+      markers.push_back(llvm::protobuf::loadVarInt(aSubBuffer));
+      break;
+    default:
+      llvm::protobuf::skipData(aSubBuffer, cur_wire);
+      break;
     }
   }
-  
+
   std::string::iterator it_name = std::find(name.begin(), name.end(), '\0');
-  llvm::SmallVector<std::size_t,8>::iterator it_mark = markers.begin();
-  while ( ( it_name != name.end() ) && ( it_mark != markers.end() ) ) {
+  llvm::SmallVector<std::size_t, 8>::iterator it_mark = markers.begin();
+  while ((it_name != name.end()) && (it_mark != markers.end())) {
     std::size_t offset = it_name - name.begin();
     name.replace(it_name, it_name + 1, templateNameMap[*it_mark]);
     it_name = std::find(name.begin() + offset, name.end(), '\0');
     ++it_mark;
   }
-  
+
   templateNameMap.push_back(name);
-  
 }
 
-static void loadLocation(llvm::StringRef aSubBuffer, 
-                         std::vector<std::string>& fileNameMap,
-                         std::string& FileName, int& Line, int& Column) {
+static void loadLocation(llvm::StringRef aSubBuffer,
+                         std::vector<std::string> &fileNameMap,
+                         std::string &FileName, int &Line, int &Column) {
   // Set default values:
   FileName = "";
   std::size_t FileID = std::numeric_limits<std::size_t>::max();
   Line = 0;
   Column = 0;
-  
-  while ( aSubBuffer.size() ) {
+
+  while (aSubBuffer.size()) {
     unsigned int cur_wire = llvm::protobuf::loadVarInt(aSubBuffer);
-    switch( cur_wire ) {
-      case llvm::protobuf::getStringWire<1>::value:
-        FileName = llvm::protobuf::loadString(aSubBuffer);
-        break;
-      case llvm::protobuf::getVarIntWire<2>::value:
-        FileID = llvm::protobuf::loadVarInt(aSubBuffer);
-        break;
-      case llvm::protobuf::getVarIntWire<3>::value:
-        Line = llvm::protobuf::loadVarInt(aSubBuffer);
-        break;
-      case llvm::protobuf::getVarIntWire<4>::value:
-        Column = llvm::protobuf::loadVarInt(aSubBuffer);
-        break;
-      default:
-        llvm::protobuf::skipData(aSubBuffer, cur_wire);
-        break;
+    switch (cur_wire) {
+    case llvm::protobuf::getStringWire<1>::value:
+      FileName = llvm::protobuf::loadString(aSubBuffer);
+      break;
+    case llvm::protobuf::getVarIntWire<2>::value:
+      FileID = llvm::protobuf::loadVarInt(aSubBuffer);
+      break;
+    case llvm::protobuf::getVarIntWire<3>::value:
+      Line = llvm::protobuf::loadVarInt(aSubBuffer);
+      break;
+    case llvm::protobuf::getVarIntWire<4>::value:
+      Column = llvm::protobuf::loadVarInt(aSubBuffer);
+      break;
+    default:
+      llvm::protobuf::skipData(aSubBuffer, cur_wire);
+      break;
     }
   }
-  
-  if ( FileID != std::numeric_limits<std::size_t>::max() ) {
-    if ( fileNameMap.size() <= FileID )
+
+  if (FileID != std::numeric_limits<std::size_t>::max()) {
+    if (fileNameMap.size() <= FileID)
       fileNameMap.resize(FileID + 1);
-    if ( !FileName.empty() ) {
-      fileNameMap[FileID] = FileName;  // overwrite existing names, if any, but there shouldn't be.
+    if (!FileName.empty()) {
+      fileNameMap[FileID] =
+          FileName; // overwrite existing names, if any, but there shouldn't be.
     } else {
       FileName = fileNameMap[FileID];
     }
   } // else we don't care?
-  
 }
 
 void TemplightProtobufReader::loadTemplateName(llvm::StringRef aSubBuffer) {
   // Set default values:
   LastBeginEntry.Name = "";
-  
-  while ( aSubBuffer.size() ) {
+
+  while (aSubBuffer.size()) {
     unsigned int cur_wire = llvm::protobuf::loadVarInt(aSubBuffer);
-    switch( cur_wire ) {
-      case llvm::protobuf::getStringWire<1>::value:
-        LastBeginEntry.Name = llvm::protobuf::loadString(aSubBuffer);
-        break;
-      case llvm::protobuf::getStringWire<2>::value: {
-        LastBeginEntry.Name = llvm::protobuf::loadString(aSubBuffer);
-        llvm::SmallVector<char,32> UBuf;
-        if ( llvm::zlib::uncompress(LastBeginEntry.Name, UBuf, LastBeginEntry.Name.size() * 2) 
-                == llvm::zlib::StatusOK )
-          LastBeginEntry.Name.assign(UBuf.begin(), UBuf.end());
-        else
-          LastBeginEntry.Name = "";
-        break;
-      }
-      case llvm::protobuf::getVarIntWire<3>::value: {
-        LastBeginEntry.Name = templateNameMap[llvm::protobuf::loadVarInt(aSubBuffer)];
-        break;
-      }
-      default:
-        llvm::protobuf::skipData(aSubBuffer, cur_wire);
-        break;
+    switch (cur_wire) {
+    case llvm::protobuf::getStringWire<1>::value:
+      LastBeginEntry.Name = llvm::protobuf::loadString(aSubBuffer);
+      break;
+    case llvm::protobuf::getStringWire<2>::value: {
+      LastBeginEntry.Name = llvm::protobuf::loadString(aSubBuffer);
+      llvm::SmallVector<char, 32> UBuf;
+      if (llvm::zlib::uncompress(LastBeginEntry.Name, UBuf,
+                                 LastBeginEntry.Name.size() * 2) ==
+          llvm::zlib::StatusOK)
+        LastBeginEntry.Name.assign(UBuf.begin(), UBuf.end());
+      else
+        LastBeginEntry.Name = "";
+      break;
+    }
+    case llvm::protobuf::getVarIntWire<3>::value: {
+      LastBeginEntry.Name =
+          templateNameMap[llvm::protobuf::loadVarInt(aSubBuffer)];
+      break;
+    }
+    default:
+      llvm::protobuf::skipData(aSubBuffer, cur_wire);
+      break;
     }
   }
-  
 }
 
 void TemplightProtobufReader::loadBeginEntry(llvm::StringRef aSubBuffer) {
@@ -157,45 +156,47 @@ void TemplightProtobufReader::loadBeginEntry(llvm::StringRef aSubBuffer) {
   LastBeginEntry.Name = "";
   LastBeginEntry.TimeStamp = 0.0;
   LastBeginEntry.MemoryUsage = 0;
-  
-  while ( aSubBuffer.size() ) {
+
+  while (aSubBuffer.size()) {
     unsigned int cur_wire = llvm::protobuf::loadVarInt(aSubBuffer);
-    switch( cur_wire ) {
-      case llvm::protobuf::getVarIntWire<1>::value:
-        LastBeginEntry.SynthesisKind = llvm::protobuf::loadVarInt(aSubBuffer);
-        break;
-      case llvm::protobuf::getStringWire<2>::value: {
-        std::uint64_t cur_size = llvm::protobuf::loadVarInt(aSubBuffer);
-        loadTemplateName(aSubBuffer.slice(0, cur_size));
-        aSubBuffer = aSubBuffer.drop_front(cur_size);
-        break;
-      }
-      case llvm::protobuf::getStringWire<3>::value: {
-        std::uint64_t cur_size = llvm::protobuf::loadVarInt(aSubBuffer);
-        loadLocation(aSubBuffer.slice(0, cur_size), fileNameMap, 
-          LastBeginEntry.FileName, LastBeginEntry.Line, LastBeginEntry.Column);
-        aSubBuffer = aSubBuffer.drop_front(cur_size);
-        break;
-      }
-      case llvm::protobuf::getDoubleWire<4>::value:
-        LastBeginEntry.TimeStamp = llvm::protobuf::loadDouble(aSubBuffer);
-        break;
-      case llvm::protobuf::getVarIntWire<5>::value:
-        LastBeginEntry.MemoryUsage = llvm::protobuf::loadVarInt(aSubBuffer);
-        break;
-      case llvm::protobuf::getStringWire<6>::value: {
-        std::uint64_t cur_size = llvm::protobuf::loadVarInt(aSubBuffer);
-        loadLocation(aSubBuffer.slice(0, cur_size), fileNameMap, 
-          LastBeginEntry.TempOri_FileName, LastBeginEntry.TempOri_Line, LastBeginEntry.TempOri_Column);
-        aSubBuffer = aSubBuffer.drop_front(cur_size);
-        break;
-      }
-      default:
-        llvm::protobuf::skipData(aSubBuffer, cur_wire);
-        break;
+    switch (cur_wire) {
+    case llvm::protobuf::getVarIntWire<1>::value:
+      LastBeginEntry.SynthesisKind = llvm::protobuf::loadVarInt(aSubBuffer);
+      break;
+    case llvm::protobuf::getStringWire<2>::value: {
+      std::uint64_t cur_size = llvm::protobuf::loadVarInt(aSubBuffer);
+      loadTemplateName(aSubBuffer.slice(0, cur_size));
+      aSubBuffer = aSubBuffer.drop_front(cur_size);
+      break;
+    }
+    case llvm::protobuf::getStringWire<3>::value: {
+      std::uint64_t cur_size = llvm::protobuf::loadVarInt(aSubBuffer);
+      loadLocation(aSubBuffer.slice(0, cur_size), fileNameMap,
+                   LastBeginEntry.FileName, LastBeginEntry.Line,
+                   LastBeginEntry.Column);
+      aSubBuffer = aSubBuffer.drop_front(cur_size);
+      break;
+    }
+    case llvm::protobuf::getDoubleWire<4>::value:
+      LastBeginEntry.TimeStamp = llvm::protobuf::loadDouble(aSubBuffer);
+      break;
+    case llvm::protobuf::getVarIntWire<5>::value:
+      LastBeginEntry.MemoryUsage = llvm::protobuf::loadVarInt(aSubBuffer);
+      break;
+    case llvm::protobuf::getStringWire<6>::value: {
+      std::uint64_t cur_size = llvm::protobuf::loadVarInt(aSubBuffer);
+      loadLocation(aSubBuffer.slice(0, cur_size), fileNameMap,
+                   LastBeginEntry.TempOri_FileName, LastBeginEntry.TempOri_Line,
+                   LastBeginEntry.TempOri_Column);
+      aSubBuffer = aSubBuffer.drop_front(cur_size);
+      break;
+    }
+    default:
+      llvm::protobuf::skipData(aSubBuffer, cur_wire);
+      break;
     }
   }
-  
+
   LastChunk = TemplightProtobufReader::BeginEntry;
 }
 
@@ -203,31 +204,31 @@ void TemplightProtobufReader::loadEndEntry(llvm::StringRef aSubBuffer) {
   // Set default values:
   LastEndEntry.TimeStamp = 0.0;
   LastEndEntry.MemoryUsage = 0;
-  
-  while ( aSubBuffer.size() ) {
+
+  while (aSubBuffer.size()) {
     unsigned int cur_wire = llvm::protobuf::loadVarInt(aSubBuffer);
-    switch( cur_wire ) {
-      case llvm::protobuf::getDoubleWire<1>::value:
-        LastEndEntry.TimeStamp = llvm::protobuf::loadDouble(aSubBuffer);
-        break;
-      case llvm::protobuf::getVarIntWire<2>::value:
-        LastEndEntry.MemoryUsage = llvm::protobuf::loadVarInt(aSubBuffer);
-        break;
-      default:
-        llvm::protobuf::skipData(aSubBuffer, cur_wire);
-        break;
+    switch (cur_wire) {
+    case llvm::protobuf::getDoubleWire<1>::value:
+      LastEndEntry.TimeStamp = llvm::protobuf::loadDouble(aSubBuffer);
+      break;
+    case llvm::protobuf::getVarIntWire<2>::value:
+      LastEndEntry.MemoryUsage = llvm::protobuf::loadVarInt(aSubBuffer);
+      break;
+    default:
+      llvm::protobuf::skipData(aSubBuffer, cur_wire);
+      break;
     }
   }
-  
+
   LastChunk = TemplightProtobufReader::EndEntry;
 }
 
-TemplightProtobufReader::LastChunkType 
-    TemplightProtobufReader::startOnBuffer(llvm::StringRef aBuffer) {
+TemplightProtobufReader::LastChunkType
+TemplightProtobufReader::startOnBuffer(llvm::StringRef aBuffer) {
   buffer = aBuffer;
   fileNameMap.clear();
   unsigned int cur_wire = llvm::protobuf::loadVarInt(buffer);
-  if ( cur_wire != llvm::protobuf::getStringWire<1>::value ) {
+  if (cur_wire != llvm::protobuf::getStringWire<1>::value) {
     buffer = llvm::StringRef();
     remainder_buffer = llvm::StringRef();
     LastChunk = TemplightProtobufReader::EndOfFile;
@@ -240,8 +241,8 @@ TemplightProtobufReader::LastChunkType
 }
 
 TemplightProtobufReader::LastChunkType TemplightProtobufReader::next() {
-  if ( buffer.empty() ) {
-    if ( remainder_buffer.empty() ) {
+  if (buffer.empty()) {
+    if (remainder_buffer.empty()) {
       LastChunk = TemplightProtobufReader::EndOfFile;
       return LastChunk;
     } else {
@@ -249,45 +250,43 @@ TemplightProtobufReader::LastChunkType TemplightProtobufReader::next() {
     }
   }
   unsigned int cur_wire = llvm::protobuf::loadVarInt(buffer);
-  switch(cur_wire) {
-    case llvm::protobuf::getStringWire<1>::value: {
-      std::uint64_t cur_size = llvm::protobuf::loadVarInt(buffer);
-      loadHeader(buffer.slice(0, cur_size));
-      buffer = buffer.drop_front(cur_size);
-      return LastChunk;
+  switch (cur_wire) {
+  case llvm::protobuf::getStringWire<1>::value: {
+    std::uint64_t cur_size = llvm::protobuf::loadVarInt(buffer);
+    loadHeader(buffer.slice(0, cur_size));
+    buffer = buffer.drop_front(cur_size);
+    return LastChunk;
+  };
+  case llvm::protobuf::getStringWire<2>::value: {
+    std::uint64_t cur_size = llvm::protobuf::loadVarInt(buffer);
+    llvm::StringRef sub_buffer = buffer.slice(0, cur_size);
+    buffer = buffer.drop_front(cur_size);
+    cur_wire = llvm::protobuf::loadVarInt(sub_buffer);
+    cur_size = llvm::protobuf::loadVarInt(sub_buffer);
+    switch (cur_wire) {
+    case llvm::protobuf::getStringWire<1>::value:
+      loadBeginEntry(sub_buffer);
+      break;
+    case llvm::protobuf::getStringWire<2>::value:
+      loadEndEntry(sub_buffer);
+      break;
+    default: // ignore for fwd-compat.
+      break;
     };
-    case llvm::protobuf::getStringWire<2>::value: {
-      std::uint64_t cur_size = llvm::protobuf::loadVarInt(buffer);
-      llvm::StringRef sub_buffer = buffer.slice(0, cur_size);
-      buffer = buffer.drop_front(cur_size);
-      cur_wire = llvm::protobuf::loadVarInt(sub_buffer);
-      cur_size = llvm::protobuf::loadVarInt(sub_buffer);
-      switch( cur_wire ) {
-        case llvm::protobuf::getStringWire<1>::value:
-          loadBeginEntry(sub_buffer);
-          break;
-        case llvm::protobuf::getStringWire<2>::value:
-          loadEndEntry(sub_buffer);
-          break;
-        default: // ignore for fwd-compat.
-          break;
-      };
-      return LastChunk;
-    };
-    case llvm::protobuf::getStringWire<3>::value: {
-      std::uint64_t cur_size = llvm::protobuf::loadVarInt(buffer);
-      loadDictionaryEntry(buffer.slice(0, cur_size));
-      buffer = buffer.drop_front(cur_size);
-      LastChunk = TemplightProtobufReader::Other;
-      return LastChunk;
-    };
-    default: { // ignore for fwd-compat.
-      llvm::protobuf::skipData(buffer, cur_wire);
-      return next(); // tail-call
-    };
+    return LastChunk;
+  };
+  case llvm::protobuf::getStringWire<3>::value: {
+    std::uint64_t cur_size = llvm::protobuf::loadVarInt(buffer);
+    loadDictionaryEntry(buffer.slice(0, cur_size));
+    buffer = buffer.drop_front(cur_size);
+    LastChunk = TemplightProtobufReader::Other;
+    return LastChunk;
+  };
+  default: { // ignore for fwd-compat.
+    llvm::protobuf::skipData(buffer, cur_wire);
+    return next(); // tail-call
+  };
   }
 }
 
-
 } // namespace clang
-

--- a/utils/ProtobufReader/TemplightProtobufReader.h
+++ b/utils/ProtobufReader/TemplightProtobufReader.h
@@ -1,4 +1,4 @@
-//===- TemplightProtobufReader.h ------ Clang Templight Protobuf Reader -*- C++ -*-===//
+//===- TemplightProtobufReader.h --------------------*- C++ -*-------------===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -19,24 +19,21 @@
 
 namespace clang {
 
-
 class TemplightProtobufReader {
 private:
-  
   llvm::StringRef buffer;
   llvm::StringRef remainder_buffer;
-  
-  std::vector< std::string > fileNameMap;
-  std::vector< std::string > templateNameMap;
-  
+
+  std::vector<std::string> fileNameMap;
+  std::vector<std::string> templateNameMap;
+
   void loadHeader(llvm::StringRef aSubBuffer);
   void loadDictionaryEntry(llvm::StringRef aSubBuffer);
   void loadTemplateName(llvm::StringRef aSubBuffer);
   void loadBeginEntry(llvm::StringRef aSubBuffer);
   void loadEndEntry(llvm::StringRef aSubBuffer);
-  
+
 public:
-  
   enum LastChunkType {
     EndOfFile = 0,
     Header,
@@ -44,24 +41,19 @@ public:
     EndEntry,
     Other
   } LastChunk;
-  
+
   unsigned int Version;
   std::string SourceName;
-  
+
   PrintableTemplightEntryBegin LastBeginEntry;
-  PrintableTemplightEntryEnd   LastEndEntry;
-  
+  PrintableTemplightEntryEnd LastEndEntry;
+
   TemplightProtobufReader();
-  
+
   LastChunkType startOnBuffer(llvm::StringRef aBuffer);
   LastChunkType next();
-  
 };
 
-
-}
+} // namespace clang
 
 #endif
-
-
-

--- a/utils/format.sh
+++ b/utils/format.sh
@@ -1,0 +1,5 @@
+for i in c cc cpp h hpp; do
+  for file in $(find -type f -name "*.$i"); do
+    clang-format -i $file
+  done
+done


### PR DESCRIPTION
```bash
$ clang-format --version
clang-format version 7.0.1 (tags/RELEASE_701/final)
$ clang-format -i $(find -type f -name "*.cpp")
$ clang-format -i $(find -type f -name "*.h")
```

I also tinkered with the top of the files in order not to introduce a newline there.