### PR TITLE
fix clang trunk changes

### DIFF
--- a/lib/TemplightAction.cpp
+++ b/lib/TemplightAction.cpp
@@ -55,7 +55,7 @@ std::string TemplightAction::CreateOutputFilename(
     // then, derive output name from the input name:
     if (CI->hasSourceManager()) {
       FileID fileID = CI->getSourceManager().getMainFileID();
-      result = CI->getSourceManager().getFileEntryForID(fileID)->getName();
+      result = CI->getSourceManager().getFileEntryForID(fileID)->getName().str();
     } else { // or, last resort:
       result = "a";
     }

--- a/lib/TemplightDebugger.cpp
+++ b/lib/TemplightDebugger.cpp
@@ -15,6 +15,7 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/Sema.h"
+#include "clang/Basic/SourceManager.h"
 
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Regex.h"
@@ -205,7 +206,7 @@ public:
 
       std::string param_name;
       if (const IdentifierInfo *Id = Params->getParam(I)->getIdentifier()) {
-        param_name = Id->getName();
+        param_name = Id->getName().str();
       } else {
         llvm::raw_string_ostream OS_param(param_name);
         OS_param << '$' << I;
@@ -217,7 +218,7 @@ public:
         PrintableQueryResult cur_result;
 
         if (QueryKind & LookForDecl) {
-          cur_result.Name = Params->getParam(I)->getName();
+          cur_result.Name = Params->getParam(I)->getName().str();
           cur_result.fromLocation(TheSema, Params->getParam(I)->getLocation(),
                                   "<unknown-location>");
         }

--- a/lib/TemplightTracer.cpp
+++ b/lib/TemplightTracer.cpp
@@ -197,7 +197,7 @@ public:
     // get the source name from the source manager:
     FileID fileID = TheSema.getSourceManager().getMainFileID();
     std::string src_name =
-        TheSema.getSourceManager().getFileEntryForID(fileID)->getName();
+        TheSema.getSourceManager().getFileEntryForID(fileID)->getName().str();
     initialize(src_name);
   };
 


### PR DESCRIPTION
Trying to build templight against current clang trunk, I encountered a handful of errors.
Mostly just StringRef -> std::string conversions that needed to be made explicit.


