### PR TITLE
Rebase on the current trunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The debugger is enabled by the templight option `-debugger`, and it supports the
 
 Templight must be compiled from source, alongside the Clang source code.
 
-1. [Follow the instructions from LLVM/Clang](http://clang.llvm.org/get_started.html) to get a local copy of the **latest git master** of the Clang source code.
+1. [Follow the instructions from LLVM/Clang](http://clang.llvm.org/get_started.html) to get a local copy of the Clang source code.
 
 2. Clone the templight repository into the clang directories, as follows:
 ```bash

--- a/lib/TemplightDebugger.cpp
+++ b/lib/TemplightDebugger.cpp
@@ -108,7 +108,7 @@ void fillWithTemplateArgumentPrints(const TemplateArgument *Args,
     } else {
       std::string Buf;
       llvm::raw_string_ostream ArgOS(Buf);
-      Args[Arg].print(Policy, ArgOS);
+      Args[Arg].print(Policy, ArgOS, /*IncludeType*/ true);
       *(It++) = Buf;
     }
   }
@@ -231,7 +231,8 @@ public:
               cur_result.Name += " with value ";
             cur_result.Name += "<empty>";
             llvm::raw_string_ostream OS_arg(cur_result.Name);
-            Args[I].print(TheSema.getPrintingPolicy(), OS_arg);
+            Args[I].print(TheSema.getPrintingPolicy(), OS_arg,
+                          /*IncludeType*/ true);
             OS_arg.str(); // flush to string.
             break;
           }
@@ -240,7 +241,9 @@ public:
             if (QueryKind & LookForValue) {
               if (!cur_result.Name.empty())
                 cur_result.Name += " with value ";
-              cur_result.Name += Args[I].getAsIntegral().toString(10);
+              llvm::SmallString<32> tmp;
+              Args[I].getAsIntegral().toString(tmp, 10);
+              cur_result.Name += tmp;
             }
             if (QueryKind & LookForType) {
               if (!cur_result.Name.empty())
@@ -363,7 +366,8 @@ public:
             if (!cur_result.Name.empty())
               cur_result.Name += " standing for ";
             llvm::raw_string_ostream OS_arg(cur_result.Name);
-            Args[I].print(TheSema.getPrintingPolicy(), OS_arg);
+            Args[I].print(TheSema.getPrintingPolicy(), OS_arg,
+                          /*IncludeType*/ true);
             OS_arg.str(); // flush to string.
             break;
           }

--- a/lib/TemplightEntryPrinter.cpp
+++ b/lib/TemplightEntryPrinter.cpp
@@ -89,7 +89,7 @@ TemplightEntryPrinter::TemplightEntryPrinter(const std::string &Output)
     TraceOS = &llvm::outs();
   } else {
     std::error_code error;
-    TraceOS = new llvm::raw_fd_ostream(Output, error, llvm::sys::fs::F_None);
+    TraceOS = new llvm::raw_fd_ostream(Output, error, llvm::sys::fs::OF_None);
     if (error) {
       llvm::errs() << "Error: [Templight] Can not open file to write trace of "
                       "template instantiations: "

--- a/templight_driver.cpp
+++ b/templight_driver.cpp
@@ -36,6 +36,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/OptTable.h"
 #include "llvm/Option/Option.h"
@@ -53,7 +54,6 @@
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/StringSaver.h"
-#include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -283,7 +283,7 @@ static void FixupDiagPrefixExeName(TextDiagnosticPrinter *DiagClient,
   // reasons, use templight-cl.exe as the prefix to avoid confusion between
   // templight and MSVC.
   StringRef ExeBasename(llvm::sys::path::filename(Path));
-  if (ExeBasename.equals_lower("cl.exe"))
+  if (ExeBasename.equals_insensitive("cl.exe"))
     ExeBasename = "templight-cl.exe";
   DiagClient->setPrefix(ExeBasename.str());
 }
@@ -331,10 +331,11 @@ static int ExecuteTemplightInvocation(CompilerInstance *Clang) {
   if (Clang->getFrontendOpts().ShowHelp) {
 
     // Print the help for the general clang options:
-    getDriverOptTable().PrintHelp(llvm::outs(), "templight",
-                    "Template Profiler and Debugger based on LLVM 'Clang' "
-                    "Compiler: http://clang.llvm.org",
-                    /*Include=*/driver::options::CC1Option, /*Exclude=*/0, false);
+    getDriverOptTable().printHelp(
+        llvm::outs(), "templight",
+        "Template Profiler and Debugger based on LLVM 'Clang' "
+        "Compiler: http://clang.llvm.org",
+        /*Include=*/driver::options::CC1Option, /*Exclude=*/0, false);
 
     return 0;
   }
@@ -559,7 +560,7 @@ int main(int argc_, const char **argv_) {
   std::string Path = GetExecutablePath(clang_argv[0], CanonicalPrefixes);
 
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts =
-      CreateAndPopulateDiagOpts(clang_argv);
+      ::CreateAndPopulateDiagOpts(clang_argv);
 
   TextDiagnosticPrinter *DiagClient =
       new TextDiagnosticPrinter(llvm::errs(), &*DiagOpts);
@@ -670,7 +671,7 @@ int main(int argc_, const char **argv_) {
       if ((!FinalOutputFilename.empty()) && (FinalOutputFilename != "-")) {
         std::error_code error;
         llvm::raw_fd_ostream TraceOS(FinalOutputFilename, error,
-                                     llvm::sys::fs::F_None);
+                                     llvm::sys::fs::OF_None);
         if (error) {
           llvm::errs() << "Error: [Templight] Can not open file to write trace "
                           "of template instantiations: "

--- a/unittests/TemplightActionTest.cpp
+++ b/unittests/TemplightActionTest.cpp
@@ -17,7 +17,8 @@
 using namespace clang;
 
 TEST(TemplightActionTest, SimpleInvocation) {
-  EXPECT_TRUE(tooling::runToolOnCode(
-      new TemplightAction{std::make_unique<TemplightDumpAction>()},
-      "void f() {;}"));
+  EXPECT_TRUE(
+      tooling::runToolOnCode(std::make_unique<TemplightAction>(
+                                 std::make_unique<TemplightDumpAction>()),
+                             "void f() {;}"));
 }


### PR DESCRIPTION
Rebase on top of this commit in the llvm monorepo:

```
commit 8cc2de667ec2526b055e971f46f4b3731107546c
Author: Kristóf Umann <dkszelethus@gmail.com>
Date:   Mon Nov 8 14:40:45 2021 +0100

    [analyzer][docs] Fix the incorrect structure of the checker docs
    
    The alpha.security.cert section came right after alpha.security, making it look
    like checkers like alpha.security.MmapWriteExec belonged to that package.
    
    Differential Revision: https://reviews.llvm.org/D113397
```