### PR TITLE
Return a non-zero exit status if there are no commands to run

### DIFF
--- a/templight_driver.cpp
+++ b/templight_driver.cpp
@@ -672,7 +672,7 @@ int main(int argc_, const char **argv_) {
   ProcessWarningOptions(Diags, *DiagOpts, /*ReportDiags=*/false);
 
   // Prepare a variable for the return value:
-  int Res = 0;
+  int Res = 1;
 
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -781,8 +781,10 @@ int main(int argc_, const char **argv_) {
     // Remove temp files.
     C->CleanupFileList(C->getTempFiles());
 
-    // If the command succeeded, the number of failing commands should zero:
-    Res = FailingCommands.size();
+    // If there were any commands, and they all succeeded, then the number of
+    // failing commands should be zero:
+    if (!C->getJobs().empty())
+      Res = FailingCommands.size();
 
     // Otherwise, remove result files and print extra information about abnormal
     // failures.


### PR DESCRIPTION
While testing out templight, I noticed a small inconsistency compared to the regular `clang` driver: if there are no commands to run (e.g. because the specified source file doesn't exist), `templight` returns an exit status of 0:

```sh
$ clang foo.cpp; echo exit status was $?
clang: error: no such file or directory: 'foo.cpp'
clang: error: no input files
exit status was 1

$ ./bin/templight foo.cpp; echo exit status was $?
templight-16: error: no such file or directory: 'foo.cpp'
templight-16: error: no input files
exit status was 0
```

Note that I changed the initial value of `Res` to be 1 so that `templight` will return a failing exit status unless the code can affirmatively state that the work succeeded. Looking over the `main` implementation, I think this change should be equivalent except in the case this is fixing.

Thanks for your work on this tool.