### PR TITLE
Handle invalid arguments to `templight` in a better way

### DIFF
--- a/templight_driver.cpp
+++ b/templight_driver.cpp
@@ -672,7 +672,7 @@ int main(int argc_, const char **argv_) {
   ProcessWarningOptions(Diags, *DiagOpts, /*ReportDiags=*/false);
 
   // Prepare a variable for the return value:
-  int Res = 1;
+  int Res = 0;
 
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -741,6 +741,10 @@ int main(int argc_, const char **argv_) {
       return 1;
     }
 
+    // If there were errors building the compilation, quit now.
+    if (TheDriver.getDiags().hasErrorOccurred())
+      return 1;
+
     SmallVector<std::pair<int, const Command *>, 4> FailingCommands;
     for (auto &J : C->getJobs())
       ExecuteTemplightCommand(TheDriver, Diags, *C, J, ClangArgs[0],
@@ -781,10 +785,8 @@ int main(int argc_, const char **argv_) {
     // Remove temp files.
     C->CleanupFileList(C->getTempFiles());
 
-    // If there were any commands, and they all succeeded, then the number of
-    // failing commands should be zero:
-    if (!C->getJobs().empty())
-      Res = FailingCommands.size();
+    // If the command succeeded, the number of failing commands should zero:
+    Res = FailingCommands.size();
 
     // Otherwise, remove result files and print extra information about abnormal
     // failures.


### PR DESCRIPTION
Sorry about the noise. After thinking about my reasoning, I realized my implementation in #96 didn't make sense: there are perfectly-valid cases where the compiler should have no commands to run, like `templight --help` or `templight --version`.

This implementation should fix that by checking whether the driver's diagnostics have logged an error. This is what `clang` itself does, using `Driver::ExecuteCompilation`: https://github.com/llvm/llvm-project/blob/357bd61744bb8cc2b9b07447294fa977e5758550/clang/lib/Driver/Driver.cpp#L1935-L1937

Since templight doesn't call that member function, it needs to handle this condition in `main`.