### PR TITLE
Improve code navigation for debugger

### DIFF
--- a/lib/TemplightDebugger.cpp
+++ b/lib/TemplightDebugger.cpp
@@ -571,7 +571,7 @@ public:
     llvm::outs() << ((Entry.IsTemplateBegin) ? "Entering " : "Leaving  ")
                  << SynthesisKindStrings[Entry.Inst.Kind] << " of "
                  << Entry.Name << '\n'
-                 << "  at " << Entry.FileName << '|' << Entry.Line << '|'
+                 << "  at " << Entry.FileName << ':' << Entry.Line << ':'
                  << Entry.Column << " (Memory usage: " << Entry.MemoryUsage
                  << ")\n";
     if (verboseMode) {
@@ -796,7 +796,7 @@ public:
                  rec.QueryResults.begin();
              it != rec.QueryResults.end(); ++it) {
           llvm::outs() << "Found " << it->Name << '\n'
-                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << "  at " << it->FileName << ':' << it->Line << ':'
                        << it->Column << '\n';
           if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
@@ -814,7 +814,7 @@ public:
                  rec.QueryResults.begin();
              it != rec.QueryResults.end(); ++it) {
           llvm::outs() << "Found " << it->Name << '\n'
-                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << "  at " << it->FileName << ':' << it->Line << ':'
                        << it->Column << '\n';
           if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
@@ -833,7 +833,7 @@ public:
                  rec.QueryResults.begin();
              it != rec.QueryResults.end(); ++it) {
           llvm::outs() << "Found " << it->Name << '\n'
-                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << "  at " << it->FileName << ':' << it->Line << ':'
                        << it->Column << '\n';
           if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
@@ -851,7 +851,7 @@ public:
                  rec.QueryResults.begin();
              it != rec.QueryResults.end(); ++it) {
           llvm::outs() << "Found " << it->Name << '\n'
-                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << "  at " << it->FileName << ':' << it->Line << ':'
                        << it->Column << '\n';
           if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
@@ -901,7 +901,7 @@ public:
                  rec.QueryResults.begin();
              it != rec.QueryResults.end(); ++it) {
           llvm::outs() << "Found " << it->Name << '\n'
-                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << "  at " << it->FileName << ':' << it->Line << ':'
                        << it->Column << '\n';
           if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
@@ -921,7 +921,7 @@ public:
                  rec.QueryResults.begin();
              it != rec.QueryResults.end(); ++it) {
           llvm::outs() << "Found " << it->Name << '\n'
-                       << "  at " << it->FileName << '|' << it->Line << '|'
+                       << "  at " << it->FileName << ':' << it->Line << ':'
                        << it->Column << '\n';
           if (verboseMode && !it->SrcPointer.empty())
             llvm::outs() << it->SrcPointer << '\n';
@@ -979,8 +979,8 @@ public:
                  EntriesStack.rbegin();
              it != EntriesStack.rend(); ++it) {
           llvm::outs() << SynthesisKindStrings[it->Inst.Kind] << " of "
-                       << it->Name << " at " << it->FileName << '|' << it->Line
-                       << '|' << it->Column << '\n';
+                       << it->Name << " at " << it->FileName << ':' << it->Line
+                       << ':' << it->Column << '\n';
         }
         continue;
       } else {


### PR DESCRIPTION
Simply replace '|' with ':' to make code navigation more user-friendly.

Now in vscode, we can use ctrl+click to locate template definitions.

![before](https://github.com/user-attachments/assets/ed17748e-be8a-4c94-a406-e2dcec3a221d)

![after](https://github.com/user-attachments/assets/a72ed58a-ae22-42bb-b2a7-14b28bfbc2a6)
