### PR TITLE
Support the latest LLVM trunk

### DIFF
--- a/templight_driver.cpp
+++ b/templight_driver.cpp
@@ -499,7 +499,7 @@ static void ExecuteTemplightCommand(
           CompilerInvocation::GetResourcesPath(Argv0, GetExecutablePathVP);
 
     // Create the compilers actual diagnostics engine.
-    Clang->createDiagnostics();
+    Clang->createDiagnostics(*llvm::vfs::getRealFileSystem());
     if (!Clang->hasDiagnostics()) {
       FailingCommands.push_back(std::make_pair(1, &J));
       return;
@@ -669,7 +669,7 @@ int main(int argc_, const char **argv_) {
         Diags.takeClient(), std::move(SerializedConsumer)));
   }
 
-  ProcessWarningOptions(Diags, *DiagOpts, /*ReportDiags=*/false);
+  ProcessWarningOptions(Diags, *DiagOpts, *llvm::vfs::getRealFileSystem(), /*ReportDiags=*/false);
 
   // Prepare a variable for the return value:
   int Res = 0;
@@ -707,7 +707,7 @@ int main(int argc_, const char **argv_) {
                                                GetExecutablePathVP);
 
     // Create the compilers actual diagnostics engine.
-    Clang->createDiagnostics();
+    Clang->createDiagnostics(*llvm::vfs::getRealFileSystem());
     if (!Clang->hasDiagnostics()) {
       return 1;
     }


### PR DESCRIPTION
Make it work with https://github.com/llvm/llvm-project/commit/7f7f540a48982d7901412502d045d7863d951ffe. Based on changes from this PR: https://github.com/llvm/llvm-project/pull/115852/.

Fixes the following compile errors:
```
/tmp/llvm-project/clang/tools/templight/templight_driver.cpp: In function ‘void ExecuteTemplightCommand(clang::driver::Driver&, clang::DiagnosticsEngine&, clang::driver::Compilation&, clang::driver::Command&, const char*, llvm::SmallVector<std::pair<int, const clang::driver::Command*>, 4>&)’:
/tmp/llvm-project/clang/tools/templight/templight_driver.cpp:502:29: error: no matching function for call to ‘clang::CompilerInstance::createDiagnostics()’
  502 |     Clang->createDiagnostics();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /tmp/llvm-project/clang/tools/templight/templight_driver.cpp:26:
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:687:8: note: candidate: ‘void clang::CompilerInstance::createDiagnostics(llvm::vfs::FileSystem&, clang::DiagnosticConsumer*, bool)’
  687 |   void createDiagnostics(llvm::vfs::FileSystem &VFS,
      |        ^~~~~~~~~~~~~~~~~
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:687:8: note:   candidate expects 3 arguments, 0 provided
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:710:3: note: candidate: ‘static llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine> clang::CompilerInstance::createDiagnostics(llvm::vfs::FileSystem&, clang::DiagnosticOptions*, clang::DiagnosticConsumer*, bool, const clang::CodeGenOptions*)’
  710 |   createDiagnostics(llvm::vfs::FileSystem &VFS, DiagnosticOptions *Opts,
      |   ^~~~~~~~~~~~~~~~~
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:710:3: note:   candidate expects 5 arguments, 0 provided
/tmp/llvm-project/clang/tools/templight/templight_driver.cpp: In function ‘int main(int, const char**)’:
/tmp/llvm-project/clang/tools/templight/templight_driver.cpp:672:59: error: invalid initialization of non-const reference of type ‘llvm::vfs::FileSystem&’ from an rvalue of type ‘bool’
  672 |   ProcessWarningOptions(Diags, *DiagOpts, /*ReportDiags=*/false);
      |                                                           ^~~~~
In file included from /tmp/llvm-project/clang/include/clang/Driver/Driver.h:12,
                 from /tmp/llvm-project/clang/tools/templight/templight_driver.cpp:21:
/tmp/llvm-project/clang/include/clang/Basic/Diagnostic.h:1791:51: note: in passing argument 3 of ‘void clang::ProcessWarningOptions(DiagnosticsEngine&, const DiagnosticOptions&, llvm::vfs::FileSystem&, bool)’
 1791 |                            llvm::vfs::FileSystem &VFS, bool ReportDiags = true);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~^~~
/tmp/llvm-project/clang/tools/templight/templight_driver.cpp:710:29: error: no matching function for call to ‘clang::CompilerInstance::createDiagnostics()’
  710 |     Clang->createDiagnostics();
      |     ~~~~~~~~~~~~~~~~~~~~~~~~^~
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:687:8: note: candidate: ‘void clang::CompilerInstance::createDiagnostics(llvm::vfs::FileSystem&, clang::DiagnosticConsumer*, bool)’
  687 |   void createDiagnostics(llvm::vfs::FileSystem &VFS,
      |        ^~~~~~~~~~~~~~~~~
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:687:8: note:   candidate expects 3 arguments, 0 provided
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:710:3: note: candidate: ‘static llvm::IntrusiveRefCntPtr<clang::DiagnosticsEngine> clang::CompilerInstance::createDiagnostics(llvm::vfs::FileSystem&, clang::DiagnosticOptions*, clang::DiagnosticConsumer*, bool, const clang::CodeGenOptions*)’
  710 |   createDiagnostics(llvm::vfs::FileSystem &VFS, DiagnosticOptions *Opts,
      |   ^~~~~~~~~~~~~~~~~
/tmp/llvm-project/clang/include/clang/Frontend/CompilerInstance.h:710:3: note:   candidate expects 5 arguments, 0 provided
make[2]: *** [tools/clang/tools/templight/CMakeFiles/templight.dir/build.make:76: tools/clang/tools/templight/CMakeFiles/templight.dir/templight_driver.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:52577: tools/clang/tools/templight/CMakeFiles/templight.dir/all] Error 2
```